### PR TITLE
Add GitHub workflow for token generation

### DIFF
--- a/.github/workflows/generate-tokens.yml
+++ b/.github/workflows/generate-tokens.yml
@@ -5,7 +5,7 @@ on:
       base_branch:
         description: "Select the base branch to merge into"
         required: true
-        default: "main"
+        default: "dev"
       target_branch:
         description: "Name of the branch to create for the PR"
         required: false


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/generate-tokens.yml` file. The change updates the default base branch for merging from "main" to "dev".

* [`.github/workflows/generate-tokens.yml`](diffhunk://#diff-e1b87bf48083827d7fb7e6c0615e431f9e012482d8f5ee9b8e9a7428e1e50847L8-R8): Changed the default base branch from "main" to "dev".