### PR TITLE
added composed case studies as dialogs.

### DIFF
--- a/frontend/src/lib/components/Dialog/DialogRoot.svelte
+++ b/frontend/src/lib/components/Dialog/DialogRoot.svelte
@@ -4,36 +4,13 @@
     import { onMount, onDestroy, tick } from 'svelte';
 	import { dialogManager } from '$lib/stores/dialogManager';
     import { browser } from '$app/environment'; // Import browser
-	import DialogSection from './DialogSection.svelte';
-    import DialogPrefix from './DialogPrefix.svelte';
-    import DialogHeader from '$lib/components/Dialog/DialogHeader.svelte';
-    import DialogAnimatedBackground from '$lib/components/Dialog/DialogAnimatedBackground.svelte';
-	import DialogTitle from './DialogTitle.svelte';
-    import DialogIntro from './DialogIntro.svelte';
-    import DialogText from './DialogText.svelte';
-	import DialogDetails from './DialogDetails.svelte';
-    import DialogPrinciples from './DialogPrinciples.svelte';
-    import DialogInsight from './DialogInsight.svelte';
-    import Image from '../content/image.svelte';
-    import DialogFooter from './DialogFooter.svelte';
 
+    import FreshaDialog from './FreshaDialog.svelte';
+    import ShellDialog from './ShellDialog.svelte';
 
-    // Images
-    import placeholder from "$lib/assets/placeholder-image.jpg"
-
-
-	// Define the ID for this specific dialog instance
-	const DIALOG_ID = 'mainPageDialog';
-
-    let dialogRootElement: HTMLDivElement; // Reference to the dialog container
-    let scrollWrapperElement: HTMLDivElement; // Reference to the scroll wrapper
-    let currentScrollTop = 0; // Track scroll position
-
-
-    $: console.log("dialogRoot store check: ", $dialogManager, 'Is active: ', $dialogManager.activeDialogId === DIALOG_ID);
 
 	// Reactive statement to check if this dialog should be active
-	$: isActive = $dialogManager.activeDialogId === DIALOG_ID;
+	$: isActive = $dialogManager.activeDialogId !==null;
 
 	// Function to close the dialog via the store
 	function handleClose() {
@@ -41,6 +18,8 @@
 	}
 
     const FOCUSABLE_SELECTOR = 'a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), details, [tabindex]:not([tabindex="-1"])';
+
+    let dialogRootElement: HTMLDivElement; // Reference to the dialog container
 
     // Function to handle keydown events
     function handleKeydown(event: KeyboardEvent) {
@@ -135,68 +114,14 @@
 	<div class="dialog-root" bind:this={dialogRootElement}>
 
 
-		<DialogHeader />
 
-
-		<div 
-            class="dialog-root-scroll-wrapper" 
-            bind:this={scrollWrapperElement} 
-            on:scroll={() => currentScrollTop = scrollWrapperElement.scrollTop}
-        >
-			<DialogAnimatedBackground scrollPosition={currentScrollTop} />
-
-            <DialogSection hasPadding={true}>
-                <DialogTitle title="FRESHA" subcopy="Helping health and beauty businesses succeed."/>
-                <DialogIntro introText="In my time at Fresha I founded and led a multidisciplinary team to designers and impliment a design system across web and iOS and Android platforms."/>
-            </DialogSection>
-
-            <DialogSection hasPadding={true}>
-                <DialogDetails/>
-            </DialogSection>
-
-            <DialogSection hasPadding={true}>
-                <DialogPrefix variant="image" src={placeholder} alt="This is an image" aspectRatio="1/1" />
-                <DialogText/>
-            </DialogSection>
-
-            <DialogSection hasPadding={true}>
-                <DialogPrefix variant="subtitle" text="flexible component composition is key."/>
-                <Image src={placeholder} alt="placeholder"/>
-            </DialogSection>
-            
-            <DialogSection hasPadding={true}>
-                <DialogPrefix variant="subtitle" text="flexible component composition is key."/>
-                <Image src={placeholder} alt="placeholder"/>
-            </DialogSection>
-
-            <DialogSection hasPadding={true} variant="full-width">
-                <Image src={placeholder} alt="placeholder"/>
-            </DialogSection>
-
-            <DialogSection hasPadding={true}>
-                <DialogPrefix variant="header" text="Principles"/>
-                <DialogPrinciples/>
-            </DialogSection>
-
-            <DialogSection hasPadding={true}>
-                <DialogInsight/>
-            </DialogSection>
-
-
-
-            <DialogSection hasPadding={true}>
-                 <DialogPrefix variant="image" src={placeholder} alt="This is an image" aspectRatio="1/1" />
-                <Image src={placeholder} alt="placeholder"/>   
-            </DialogSection>
-
-            <DialogSection hasPadding={true} variant="full-width">
-                 <DialogFooter/>   
-            </DialogSection>
-
-            
-            
-
-		</div>
+        
+        {#if $dialogManager.activeDialogId === 'freshaDialog'}
+            <FreshaDialog/>
+        {:else if $dialogManager.activeDialogId === 'shellDialog'}
+            <ShellDialog/>
+        {/if}
+			
 	</div>
 {/if}
 

--- a/frontend/src/lib/components/Dialog/FreshaDialog.svelte
+++ b/frontend/src/lib/components/Dialog/FreshaDialog.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+
+    import { DialogSection,DialogText, DialogAnimatedBackground, DialogDetails, DialogFooter, DialogHeader, DialogInsight, DialogIntro, DialogPrefix, DialogPrinciples, DialogTitle } from './index'
+    import Image from '../content/image.svelte';
+
+
+
+  // Images
+    import placeholder from "$lib/assets/placeholder-image.jpg"
+
+
+        let scrollWrapperElement: HTMLDivElement; // Reference to the scroll wrapper
+        let currentScrollTop = 0; // Track scroll position
+</script>
+
+            
+            <DialogHeader />
+            
+            <DialogAnimatedBackground scrollPosition={currentScrollTop}/>
+
+            <div 
+            class="dialog-root-scroll-wrapper" 
+            bind:this={scrollWrapperElement} 
+            on:scroll={() => currentScrollTop = scrollWrapperElement.scrollTop}
+        >
+
+            <DialogSection hasPadding={true}>
+                <DialogTitle title="FRESHA" subcopy="Helping health and beauty businesses succeed."/>
+                <DialogIntro introText="In my time at Fresha I founded and led a multidisciplinary team to designers and impliment a design system across web and iOS and Android platforms."/>
+            </DialogSection>
+
+            <DialogSection hasPadding={true}>
+                <DialogDetails/>
+            </DialogSection>
+
+            <DialogSection hasPadding={true}>
+                <DialogPrefix variant="image" src={placeholder} alt="This is an image" aspectRatio="1/1" />
+                <DialogText/>
+            </DialogSection>
+
+            <DialogSection hasPadding={true}>
+                <DialogPrefix variant="subtitle" text="flexible component composition is key."/>
+                <Image src={placeholder} alt="placeholder"/>
+            </DialogSection>
+            
+            <DialogSection hasPadding={true}>
+                <DialogPrefix variant="subtitle" text="flexible component composition is key."/>
+                <Image src={placeholder} alt="placeholder"/>
+            </DialogSection>
+
+            <DialogSection hasPadding={true} variant="full-width">
+                <Image src={placeholder} alt="placeholder"/>
+            </DialogSection>
+
+            <DialogSection hasPadding={true}>
+                <DialogPrefix variant="header" text="Principles"/>
+                <DialogPrinciples/>
+            </DialogSection>
+
+            <DialogSection hasPadding={true}>
+                <DialogInsight/>
+            </DialogSection>
+
+
+
+            <DialogSection hasPadding={true}>
+                 <DialogPrefix variant="image" src={placeholder} alt="This is an image" aspectRatio="1/1" />
+                <Image src={placeholder} alt="placeholder"/>   
+            </DialogSection>
+
+            <DialogSection hasPadding={true} variant="full-width">
+                 <DialogFooter/>   
+            </DialogSection>
+
+            
+            </div>
+
+            <style>
+
+        .dialog-root-scroll-wrapper {
+		width: 100%;
+		overflow-y: auto; /* Enable vertical scrolling for content */
+		scrollbar-width: none;
+        padding-top: 124px;
+	}
+
+    </style>

--- a/frontend/src/lib/components/Dialog/ShellDialog.svelte
+++ b/frontend/src/lib/components/Dialog/ShellDialog.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+
+    import { DialogSection,DialogText, DialogAnimatedBackground, DialogDetails, DialogFooter, DialogHeader, DialogInsight, DialogIntro, DialogPrefix, DialogPrinciples, DialogTitle } from './index'
+    import Image from '../content/image.svelte';
+
+
+
+  // Images
+    import placeholder from "$lib/assets/placeholder-image.jpg"
+
+
+        let scrollWrapperElement: HTMLDivElement; // Reference to the scroll wrapper
+        let currentScrollTop = 0; // Track scroll position
+</script>
+
+            
+            <DialogHeader />
+            
+            <DialogAnimatedBackground scrollPosition={currentScrollTop}/>
+
+            <div 
+            class="dialog-root-scroll-wrapper" 
+            bind:this={scrollWrapperElement} 
+            on:scroll={() => currentScrollTop = scrollWrapperElement.scrollTop}
+        >
+
+            <DialogSection hasPadding={true}>
+                <DialogTitle title="SHELL" subcopy="Drill Baby Drill!"/>
+                <DialogIntro introText="In my time at Fresha I founded and led a multidisciplinary team to designers and impliment a design system across web and iOS and Android platforms."/>
+            </DialogSection>
+
+            <DialogSection hasPadding={true}>
+                <DialogDetails/>
+            </DialogSection>
+
+            <DialogSection hasPadding={true}>
+                <DialogPrefix variant="image" src={placeholder} alt="This is an image" aspectRatio="1/1" />
+                <DialogText/>
+            </DialogSection>
+
+            <DialogSection hasPadding={true}>
+                <DialogPrefix variant="subtitle" text="flexible component composition is key."/>
+                <Image src={placeholder} alt="placeholder"/>
+            </DialogSection>
+
+
+
+            <DialogSection hasPadding={true}>
+                 <DialogPrefix variant="image" src={placeholder} alt="This is an image" aspectRatio="1/1" />
+                <Image src={placeholder} alt="placeholder"/>   
+            </DialogSection>
+
+            <DialogSection hasPadding={true} variant="full-width">
+                 <DialogFooter/>   
+            </DialogSection>
+
+            
+            </div>
+
+            <style>
+
+        .dialog-root-scroll-wrapper {
+		width: 100%;
+		overflow-y: auto; /* Enable vertical scrolling for content */
+		scrollbar-width: none;
+        padding-top: 124px;
+	}
+
+    </style>

--- a/frontend/src/lib/components/Dialog/index.js
+++ b/frontend/src/lib/components/Dialog/index.js
@@ -1,3 +1,14 @@
-export { default as DialogRoot } from './DialogRoot.svelte';
+export { default as DialogAnimatedBackground } from './DialogAnimatedBackground.svelte';
+export { default as DialogDetails } from './DialogDetails.svelte';
+export { default as DialogFooter } from './DialogFooter.svelte';
 export { default as DialogHeader } from './DialogHeader.svelte';
-export { default as DialogContent } from './DialogContent.svelte';
+export { default as DialogInsight } from './DialogInsight.svelte';
+export { default as DialogIntro } from './DialogIntro.svelte';
+export { default as DialogPrefix } from './DialogPrefix.svelte';
+export { default as DialogPrinciples } from './DialogPrinciples.svelte';
+export { default as DialogRoot } from './DialogRoot.svelte';
+export { default as DialogSection } from './DialogSection.svelte';
+export { default as DialogText } from './DialogText.svelte';
+export { default as DialogTitle } from './DialogTitle.svelte';
+export { default as FreshaDialog } from './FreshaDialog.svelte';
+export { default as ImageGrid } from './ImageGrid.svelte';

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -11,7 +11,6 @@
     import SideBar from "$lib/components/navigation/SideBar.svelte";
     import { HeroRoot, HeroTitle, HeroIntro, HeroButton } from "$lib/components/content/Hero";
     import Callout from "$lib/components/feedback/Callout.svelte";
-    //Icons
     import { dialogManager } from '$lib/stores/dialogManager';
     import DialogRoot from '$lib/components/Dialog/DialogRoot.svelte';
 
@@ -22,6 +21,13 @@
     function openTheDialog() {
         console.log('Opening dialog...');
         dialogManager.showDialog('mainPageDialog', { message: 'Hello from the page!' });
+    }
+
+    function openFreshaDialog() {
+        dialogManager.showDialog('freshaDialog')
+    }
+    function openShellDialog() {
+        dialogManager.showDialog('shellDialog')
     }
 
     $: currentPath = $page.url.pathname;
@@ -50,9 +56,9 @@
         <HeroRoot>
             <HeroTitle />
             <HeroIntro color="secondary">
-                I've worked with scaleups such as <HeroButton on:click={openTheDialog} label="Fresha"/>,
+                I've worked with scaleups such as <HeroButton on:click={openFreshaDialog} label="Fresha"/>,
                 Co-founded a <HeroButton on:click={openTheDialog} label="startup" />.
-                I've also delivered digital transformational solutions for <HeroButton on:click={openTheDialog} label="Shell"/>
+                I've also delivered digital transformational solutions for <HeroButton on:click={openShellDialog} label="Shell"/>
                 <HeroButton on:click={openTheDialog} label="Suzuki"/>,
                 <HeroButton on:click={openTheDialog} label="TSB"/> and,
                 <HeroButton on:click={openTheDialog} label="AXA"/>.


### PR DESCRIPTION
This pull request refactors the dialog system in the frontend by modularizing dialog components and introducing specific dialog implementations for "Fresha" and "Shell". The changes improve code organization, enhance maintainability, and simplify the logic for rendering dialogs based on the active dialog ID.

### Refactoring and modularization of dialog components:
* [`frontend/src/lib/components/Dialog/DialogRoot.svelte`](diffhunk://#diff-b82cebf9fb64b2fd006d9dda690af56468c3a4e388205379b8da1fbe429eb606L7-R13): Removed inline dialog content and replaced it with conditional rendering of `FreshaDialog` and `ShellDialog` components based on the active dialog ID. Unused imports and variables were also removed. [[1]](diffhunk://#diff-b82cebf9fb64b2fd006d9dda690af56468c3a4e388205379b8da1fbe429eb606L7-R13) [[2]](diffhunk://#diff-b82cebf9fb64b2fd006d9dda690af56468c3a4e388205379b8da1fbe429eb606L138-L199)
* [`frontend/src/lib/components/Dialog/index.js`](diffhunk://#diff-5180b76e426637bb9ff2cdeead91462e392656c5f41f1121fd71675ba3c3dd40L1-R14): Updated exports to include new modular dialog components (`FreshaDialog`, `ShellDialog`, and others) and removed unused exports.

### New dialog components:
* [`frontend/src/lib/components/Dialog/FreshaDialog.svelte`](diffhunk://#diff-1fb44de2fd59930a87e5c40a39ce1b6cdc5def944d32e48189137ac5d9476abfR1-R87): Added a dedicated component for the Fresha dialog, encapsulating its structure and behavior.
* [`frontend/src/lib/components/Dialog/ShellDialog.svelte`](diffhunk://#diff-c310f9c76bc97b2683b4ca4fd61b307b643fa55171c412210cb39a3b53d13c14R1-R69): Added a dedicated component for the Shell dialog, encapsulating its structure and behavior.

### Updates to dialog usage in the main page:
* [`frontend/src/routes/+page.svelte`](diffhunk://#diff-277e5e66aac69da7616117de4cb91d3988aab163a62ebf7252f86fa6cf4b39eeL14): Updated dialog triggers to use the new `openFreshaDialog` and `openShellDialog` functions, which activate the corresponding dialogs via the `dialogManager` store. [[1]](diffhunk://#diff-277e5e66aac69da7616117de4cb91d3988aab163a62ebf7252f86fa6cf4b39eeL14) [[2]](diffhunk://#diff-277e5e66aac69da7616117de4cb91d3988aab163a62ebf7252f86fa6cf4b39eeR26-R32) [[3]](diffhunk://#diff-277e5e66aac69da7616117de4cb91d3988aab163a62ebf7252f86fa6cf4b39eeL53-R61)