### PR TITLE
added initial data set for dialog

### DIFF
--- a/frontend/src/lib/components/Dialog/DialogDetails.svelte
+++ b/frontend/src/lib/components/Dialog/DialogDetails.svelte
@@ -16,13 +16,13 @@ const defaultDetails: ProjectDetail[] = [
 ]
 
 interface DialogDetailsProps{
-    projectSections?:string[]; // array of strings
+    sections?:string[]; // array of strings
     projectDetails?: ProjectDetail[]; // array of objects
 }
 
 
 
-let {projectDetails=defaultDetails, projectSections=defaultSections} : DialogDetailsProps = $props();
+let {projectDetails=defaultDetails, sections=defaultSections} : DialogDetailsProps = $props();
 
 </script>
 
@@ -39,7 +39,7 @@ let {projectDetails=defaultDetails, projectSections=defaultSections} : DialogDet
 <div class="layout">
     <span class="title">Contents</span>
     <ul>
-        {#each projectSections as sections}
+        {#each sections as sections}
            <li>{sections}</li> 
         {/each}
     </ul>

--- a/frontend/src/lib/components/Dialog/DialogInsight.svelte
+++ b/frontend/src/lib/components/Dialog/DialogInsight.svelte
@@ -22,7 +22,7 @@
         data?: InsightData
     }
 
-    let { data = exampleInsightData, } : InsightButton = $props();
+    let { label=exampleInsightData.label, number=exampleInsightData.number, insight=exampleInsightData.insight } : InsightData = $props();
 
     let isVisible: boolean = $state(false)
 
@@ -37,13 +37,13 @@
 
 
 
-<button aria-label={exampleInsightData.label} onclick={handleInsightClick}>
+<button aria-label={label} onclick={handleInsightClick}>
     <div class="insight-header">
-        <p>{exampleInsightData.label}</p>
-        <p>{exampleInsightData.number}</p>
+        <p>{label}</p>
+        <p>{number}</p>
     </div>
     <span style={`filter: blur(${isVisible ? '0px' : '6px' });`}>
-        {exampleInsightData.insight}
+        {insight}
     </span>
 
 </button>

--- a/frontend/src/lib/components/Dialog/DialogRoot.svelte
+++ b/frontend/src/lib/components/Dialog/DialogRoot.svelte
@@ -139,12 +139,6 @@
 		cursor: default; 
 	}
 
-	.dialog-root-scroll-wrapper {
-		width: 100%;
-		overflow-y: auto; /* Enable vertical scrolling for content */
-		scrollbar-width: none;
-        padding-top: 124px;
-	}
 
 	.dialog-root {
 		position: fixed; /* Position independently */

--- a/frontend/src/lib/components/Dialog/DialogSection.svelte
+++ b/frontend/src/lib/components/Dialog/DialogSection.svelte
@@ -4,7 +4,7 @@
   type SectionVariant = 'default' | 'full-width' 
 
  interface SectionProps {
-
+  id?:string
   hasPadding: Boolean;
   children?: Snippet;
   variant?: SectionVariant;

--- a/frontend/src/lib/components/Dialog/FreshaDialog.svelte
+++ b/frontend/src/lib/components/Dialog/FreshaDialog.svelte
@@ -1,12 +1,63 @@
 <script lang="ts">
 
-    import { DialogSection,DialogText, DialogAnimatedBackground, DialogDetails, DialogFooter, DialogHeader, DialogInsight, DialogIntro, DialogPrefix, DialogPrinciples, DialogTitle } from './index'
+    import { DialogSection,DialogText, DialogAnimatedBackground, DialogDetails, DialogFooter, DialogHeader, DialogInsight, DialogIntro, DialogPrefix, DialogPrinciples, DialogTitle, FreshaDialog } from './index'
     import Image from '../content/image.svelte';
 
+    
 
 
   // Images
     import placeholder from "$lib/assets/placeholder-image.jpg"
+
+    const freshaData = {
+    title:{
+    title: "Fresha",
+    subcopy: "Empowering health and beauty for everyone",
+    introText: "During my time at Fresha, I founded and led a multidisciplinary team of designers and engineers to develop a design system across Web, iOS, and Android platforms. This resulted in a best-in-class user experience and highly automated system that catalyzed rapid global growth.",
+    },
+
+    details:{
+    projectSections: ["Overview", "Key challenges"],
+    projectDetails: [
+        { title: "Role", details: "Lead Product Designer" },
+        { title: "Date", details: "2020-2023" }
+    ]
+    },
+
+    overview:{
+        alt:"placeholder alt text",
+        overviewText:"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+    },
+
+    graphicOne:{
+        prefixVariant:"subtitle",
+        prefixText:"Flexible component composition is key.",
+        alt:"placeholder alt text"
+    },
+
+     graphicTwo:{
+        prefixVariant:"subtitle",
+        prefixText:"Flexible component composition is key.",
+        alt:"placeholder alt text"
+    },
+
+    bigGraphic:{
+        image:{placeholder},
+        alt:"placeholder alt text"
+    },
+
+    principles:{
+        prefixVariant:"header",
+        prefixText:"Principles"
+    },
+
+    insightOne:{
+        insightLabel: "Insight dummy",
+        insightNumber: "01",
+        insightText:"dummy insight data about something insightfull and interesting to do with the case study"
+    },
+};
+
 
 
         let scrollWrapperElement: HTMLDivElement; // Reference to the scroll wrapper
@@ -24,49 +75,43 @@
             on:scroll={() => currentScrollTop = scrollWrapperElement.scrollTop}
         >
 
-            <DialogSection hasPadding={true}>
-                <DialogTitle title="FRESHA" subcopy="Helping health and beauty businesses succeed."/>
-                <DialogIntro introText="In my time at Fresha I founded and led a multidisciplinary team to designers and impliment a design system across web and iOS and Android platforms."/>
+            <DialogSection id="title" hasPadding={true}>
+                <DialogTitle title="{freshaData.title.title}" subcopy={freshaData.title.subcopy}/>
+                <DialogIntro introText={freshaData.title.introText}/>
             </DialogSection>
 
-            <DialogSection hasPadding={true}>
-                <DialogDetails/>
+            <DialogSection id="details" hasPadding={true}>
+                <DialogDetails projectDetails={freshaData.details.projectDetails} sections={freshaData.details.projectSections} />
             </DialogSection>
 
-            <DialogSection hasPadding={true}>
+            <DialogSection id="overview" hasPadding={true}>
                 <DialogPrefix variant="image" src={placeholder} alt="This is an image" aspectRatio="1/1" />
                 <DialogText/>
             </DialogSection>
 
-            <DialogSection hasPadding={true}>
-                <DialogPrefix variant="subtitle" text="flexible component composition is key."/>
-                <Image src={placeholder} alt="placeholder"/>
+            <DialogSection id="graphic one" hasPadding={true}>
+                <DialogPrefix variant="subtitle" text={freshaData.graphicOne.prefixText}/>
+                <Image src={placeholder} alt={freshaData.graphicOne.alt}/>
             </DialogSection>
             
-            <DialogSection hasPadding={true}>
+            <DialogSection id="graphic two" hasPadding={true}>
                 <DialogPrefix variant="subtitle" text="flexible component composition is key."/>
                 <Image src={placeholder} alt="placeholder"/>
             </DialogSection>
 
-            <DialogSection hasPadding={true} variant="full-width">
+            <DialogSection id="big graphic" hasPadding={true} variant="full-width">
                 <Image src={placeholder} alt="placeholder"/>
             </DialogSection>
 
-            <DialogSection hasPadding={true}>
+            <DialogSection id="principles" hasPadding={true}>
                 <DialogPrefix variant="header" text="Principles"/>
                 <DialogPrinciples/>
             </DialogSection>
 
-            <DialogSection hasPadding={true}>
-                <DialogInsight/>
+            <DialogSection id="insight one" hasPadding={true}>
+                <DialogInsight label={freshaData.insightOne.insightLabel} number={freshaData.insightOne.insightNumber} insight={freshaData.insightOne.insightText}/>
             </DialogSection>
 
-
-
-            <DialogSection hasPadding={true}>
-                 <DialogPrefix variant="image" src={placeholder} alt="This is an image" aspectRatio="1/1" />
-                <Image src={placeholder} alt="placeholder"/>   
-            </DialogSection>
 
             <DialogSection hasPadding={true} variant="full-width">
                  <DialogFooter/>   


### PR DESCRIPTION
This pull request refactors several `Dialog` components in the frontend codebase to improve maintainability and flexibility, introduces a centralized data structure for the `FreshaDialog` component, and removes unused styles. The most important changes include renaming and standardizing prop names, updating components to use dynamic data, and cleaning up unused CSS.

### Refactoring and Prop Standardization:
* Renamed `projectSections` to `sections` in `DialogDetails` to simplify and standardize prop naming. Updated all references accordingly. (`frontend/src/lib/components/Dialog/DialogDetails.svelte`, [[1]](diffhunk://#diff-61ad39539a0d41681672baee61d60bd30c12d70cfbf7c56df79d48ad68208142L19-R25) [[2]](diffhunk://#diff-61ad39539a0d41681672baee61d60bd30c12d70cfbf7c56df79d48ad68208142L42-R42)
* Updated `DialogInsight` to destructure individual properties (`label`, `number`, `insight`) from the `InsightData` object, replacing the previous single `data` prop. Updated all references to use these properties. (`frontend/src/lib/components/Dialog/DialogInsight.svelte`, [[1]](diffhunk://#diff-ed91d3649c0f5f74d474459362d7120c11a23bf9ac2604fb27134e04d02cac7aL25-R25) [[2]](diffhunk://#diff-ed91d3649c0f5f74d474459362d7120c11a23bf9ac2604fb27134e04d02cac7aL40-R46)

### Centralized Data Structure:
* Introduced a centralized `freshaData` object in `FreshaDialog` to manage all data for the dialog dynamically. Updated child components to use this data for content and configuration. (`frontend/src/lib/components/Dialog/FreshaDialog.svelte`, [[1]](diffhunk://#diff-1fb44de2fd59930a87e5c40a39ce1b6cdc5def944d32e48189137ac5d9476abfL3-R61) [[2]](diffhunk://#diff-1fb44de2fd59930a87e5c40a39ce1b6cdc5def944d32e48189137ac5d9476abfL27-L70)

### Component Enhancements:
* Added an optional `id` prop to `DialogSection` to allow unique identification of sections, improving flexibility for dynamic rendering. (`frontend/src/lib/components/Dialog/DialogSection.svelte`, [frontend/src/lib/components/Dialog/DialogSection.svelteL7-R7](diffhunk://#diff-40a744146b95a7e36b3a885e8885be3dc46b12c02f305691a2f14b52d018f686L7-R7))

### CSS Cleanup:
* Removed unused `.dialog-root-scroll-wrapper` styles from `DialogRoot`, as the associated functionality is no longer needed. (`frontend/src/lib/components/Dialog/DialogRoot.svelte`, [frontend/src/lib/components/Dialog/DialogRoot.svelteL142-L147](diffhunk://#diff-b82cebf9fb64b2fd006d9dda690af56468c3a4e388205379b8da1fbe429eb606L142-L147))