### PR TITLE
refactor: add webkit button overides to accordion component

### DIFF
--- a/frontend/src/lib/components/accordian/Accordian.svelte
+++ b/frontend/src/lib/components/accordian/Accordian.svelte
@@ -70,6 +70,8 @@
     }
 
     button{
+        -webkit-appearance: none;
+        appearance: none;
         display: flex;
         flex-direction: row;
         justify-content: flex-start;


### PR DESCRIPTION
This pull request includes a small change to the `Accordian.svelte` file. The change ensures that buttons within the accordion component have their default appearance removed by adding `-webkit-appearance: none;` and `appearance: none;` styles.