### PR TITLE
hotfix: replace type

### DIFF
--- a/frontend/src/lib/types/icons.ts
+++ b/frontend/src/lib/types/icons.ts
@@ -7,7 +7,7 @@ export type IconName =
     | '02d' | '02n' // Fewd Clouds
     | '03d' | '03n' // Scattered Clouds
     | '04d' | '04n' // Broken Clouds
-    | '00d' | '09n' // Shower Rain
+    | '09d' | '09n' // Shower Rain
     | '10d' | '10n' // Rain
     | '11d' | '11n' // Thunderstorm
     | '13d' | '13n' // Snow


### PR DESCRIPTION
This pull request includes a small correction to the `IconName` type in the `frontend/src/lib/types/icons.ts` file. The change updates the daytime icon for "Shower Rain" from `'00d'` to `'09d'` to ensure consistency with the intended weather icon set.