### PR TITLE
refactor: add function to header to set theme

### DIFF
--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -5,6 +5,18 @@
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		%sveltekit.head%
+
+		<!-- THEMING -->
+		<script>
+				// Apply theme immediately before any rendering
+				(function() {
+					const saved = localStorage.getItem('theme');
+					const systemPrefers = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+					const theme = saved || systemPrefers;
+					document.documentElement.setAttribute('data-theme', theme);
+				})();
+		</script>
+		
 	</head>
 	<body data-sveltekit-preload-data="hover">
 		<div style="display: contents">%sveltekit.body%</div>


### PR DESCRIPTION
This pull request introduces a small but impactful change to the `frontend/src/app.html` file. It adds a script to apply a theme immediately based on the user's saved preference or system's color scheme.

- [`frontend/src/app.html`](diffhunk://#diff-cb360f4efb5052592ab62e117411fbf197f843f20528ea6877c940bfd5e824a8R8-R19): Added a script to dynamically set the `data-theme` attribute on the `document.documentElement` based on the user's saved theme in `localStorage` or the system's color scheme preference.