### PR TITLE
refactor: implimented control overrides on videocard to stope safar s…

### DIFF
--- a/frontend/src/lib/components/cards/VideoCard.svelte
+++ b/frontend/src/lib/components/cards/VideoCard.svelte
@@ -73,7 +73,9 @@
 		{src}
 		muted
 		loop
+		playsinline
 		preload="metadata"
+		controls={false}
 		style="background-color: {bgColor};"
 	>
 		<track kind="captions" />
@@ -124,6 +126,19 @@
 		height: 100%;
 		object-fit: cover;
 		z-index: 0;
+		-webkit-appearance: none;
+		-webkit-media-controls: none;
+		-webkit-media-controls-panel: none;
+		-webkit-media-controls-play-button: none;
+		-webkit-media-controls-start-playback-button: none;
+	}
+
+	.cover-video::-webkit-media-controls {
+		display: none !important;
+	}
+
+	.cover-video::-webkit-media-controls-panel {
+		display: none !important;
 	}
 
 	.play-indicator {


### PR DESCRIPTION
This pull request updates the `VideoCard.svelte` component to enhance video playback behavior and styling. The changes focus on disabling default media controls for a more customized video experience.

Enhancements to video playback behavior:

* Added the `playsinline` attribute to ensure videos play inline rather than in fullscreen on mobile devices.
* Set `controls={false}` to disable the browser's default video controls.

Customizations to video styling:

* Disabled various WebKit-specific media controls using CSS, including the play button and playback panel, for a cleaner video interface.…pecific behavior