### PR TITLE
Feature/graphics

### DIFF
--- a/frontend/src/lib/components/grids/GridLayout.svelte
+++ b/frontend/src/lib/components/grids/GridLayout.svelte
@@ -5,7 +5,7 @@
 	export interface GridItem {
 		readonly id: string;
 		readonly component: any;
-		readonly size: '1-1' | '2-2' | '4-2';
+		readonly size: '2-2' | '4-2';
 		readonly props?: Record<string, any>;
 	}
 
@@ -17,7 +17,6 @@
 	let { items, columns = 4 }: Props = $props();
 
 	const sizeMap = {
-		'1-1': { cols: 1, rows: 1 }, // small square
 		'2-2': { cols: 2, rows: 2 }, // large square
 		'4-2': { cols: 4, rows: 2 } // large rectangle
 	} as const;

--- a/frontend/src/routes/graphics/+page.svelte
+++ b/frontend/src/routes/graphics/+page.svelte
@@ -27,7 +27,7 @@
 		{
 			id: '2',
 			component: VideoCard,
-			size: '1-1',
+			size: '2-2',
 			props: {
 				src: ExampleVid,
 				bgColor: '#e3f2fd',
@@ -37,7 +37,7 @@
 		{
 			id: '3',
 			component: VideoCard,
-			size: '1-1',
+			size: '2-2',
 			props: {
 				src: ExampleVid,
 				bgColor: '#e3f2fd',
@@ -70,7 +70,7 @@
 		{
 			id: '6',
 			component: ImageCard,
-			size: '1-1',
+			size: '2-2',
 			props: {
 				src: exampleImageOne,
 				bgColor: '#FFFFFF',
@@ -80,7 +80,7 @@
 		{
 			id: '7',
 			component: ImageCard,
-			size: '1-1',
+			size: '2-2',
 			props: {
 				src: exampleImageOne,
 				bgColor: '#FFFFFF',
@@ -90,7 +90,7 @@
 		{
 			id: '8',
 			component: ImageCard,
-			size: '1-1',
+			size: '2-2',
 			props: {
 				src: exampleImageOne,
 				bgColor: '#FFFFFF',
@@ -100,7 +100,7 @@
 		{
 			id: '9',
 			component: ImageCard,
-			size: '1-1',
+			size: '2-2',
 			props: {
 				src: exampleImageOne,
 				bgColor: '#FFFFFF',
@@ -110,7 +110,7 @@
 		{
 			id: '10',
 			component: ImageCard,
-			size: '1-1',
+			size: '2-2',
 			props: {
 				src: exampleImageOne,
 				bgColor: '#FFFFFF',
@@ -133,7 +133,7 @@
 		{
 			id: '12',
 			component: ImageCard,
-			size: '1-1',
+			size: '2-2',
 			props: {
 				src: exampleImageOne,
 				bgColor: '#FFFFFF',
@@ -143,7 +143,7 @@
 		{
 			id: '13',
 			component: ImageCard,
-			size: '1-1',
+			size: '2-2',
 			props: {
 				src: exampleImageOne,
 				bgColor: '#FFFFFF',


### PR DESCRIPTION
This pull request updates the `GridLayout` component and its usage across the application to remove the `1-1` size option and replace it with `2-2`. This change ensures consistency in the grid layout and simplifies the size options available for grid items.

### Changes to the `GridLayout` component:

* Removed the `1-1` size option from the `GridItem` interface in `frontend/src/lib/components/grids/GridLayout.svelte`, leaving only `2-2` and `4-2`.
* Updated the `sizeMap` object in `frontend/src/lib/components/grids/GridLayout.svelte` to remove the mapping for `1-1`.

### Updates to grid item configurations:

* Replaced all occurrences of `size: '1-1'` with `size: '2-2'` in `frontend/src/routes/graphics/+page.svelte` for various grid items, including `VideoCard` and `ImageCard` components. [[1]](diffhunk://#diff-f9c932dfe3fd27510726609abb9129112aa933e419c81e83c51ec4fdec6fea03L30-R30) [[2]](diffhunk://#diff-f9c932dfe3fd27510726609abb9129112aa933e419c81e83c51ec4fdec6fea03L40-R40) [[3]](diffhunk://#diff-f9c932dfe3fd27510726609abb9129112aa933e419c81e83c51ec4fdec6fea03L73-R73) [[4]](diffhunk://#diff-f9c932dfe3fd27510726609abb9129112aa933e419c81e83c51ec4fdec6fea03L83-R83) [[5]](diffhunk://#diff-f9c932dfe3fd27510726609abb9129112aa933e419c81e83c51ec4fdec6fea03L93-R93) [[6]](diffhunk://#diff-f9c932dfe3fd27510726609abb9129112aa933e419c81e83c51ec4fdec6fea03L103-R103) [[7]](diffhunk://#diff-f9c932dfe3fd27510726609abb9129112aa933e419c81e83c51ec4fdec6fea03L113-R113) [[8]](diffhunk://#diff-f9c932dfe3fd27510726609abb9129112aa933e419c81e83c51ec4fdec6fea03L136-R136) [[9]](diffhunk://#diff-f9c932dfe3fd27510726609abb9129112aa933e419c81e83c51ec4fdec6fea03L146-R146)