### PR TITLE
refactor: renames components and adjusts style and layouts

### DIFF
--- a/frontend/src/lib/components/content/projects/ProjectBody.svelte
+++ b/frontend/src/lib/components/content/projects/ProjectBody.svelte
@@ -1,175 +1,126 @@
 <script lang="ts">
-	import type { Snippet } from 'svelte';
-	import placeholderImage from '$lib/assets/placeholder-image.jpg';
-	import Subheader from '../../primatives/Subheader.svelte';
+	import List from '../../primatives/List.svelte';
+	import { Subheader } from '$lib/components/primatives';
 
-	// Interface for props following ComponentRules.md patterns
-	interface ProjectBodyProps {
-		leadingContent?: Snippet;
-		trailingContent?: Snippet;
-		content?: string;
-		imageSrc?: string;
-		imageAlt?: string;
+	// Interface for props
+	interface ProjectHeaderProps {
+		impact?: {
+			title: string;
+			content: string;
+		};
+		teamMembers?: {
+			title: string;
+			members: { name: string; role: string }[];
+		};
 	}
 
-	let { leadingContent, trailingContent, content, imageSrc, imageAlt }: ProjectBodyProps = $props();
+	let { impact, teamMembers }: ProjectHeaderProps = $props();
 
 	// Dummy placeholder data for debugging
-	const defaultContent =
-		'This project involved extensive user research, iterative design processes, and close collaboration with development teams to deliver a solution that met both user needs and business objectives. The approach focused on understanding user pain points through interviews and usability testing, followed by rapid prototyping and validation cycles.';
+	const defaultImpact = {
+		title: 'Impact',
+		content: '10X revenue growth to $300+ MRR'
+	};
 
-	// Use provided props or fallback to defaults
-	const displayContent = content || defaultContent;
-	const displayImageSrc = imageSrc || placeholderImage;
-	const displayImageAlt = imageAlt || 'Project placeholder image';
+	const defaultTeamMembers = {
+		title: 'Team Members',
+		members: [
+			{ name: 'Sarah Chen', role: 'Lead Designer' },
+			{ name: 'Marcus Rodriguez', role: 'Frontend Developer' }
+		]
+	};
+
+	// Use provided props or fallback to defaults for debugging
+	const impactData = impact || defaultImpact;
+	const teamMembersData = teamMembers || defaultTeamMembers;
 </script>
 
-<!-- leadingContent snippet -->
-{#snippet defaultLeadingContent()}
-	<div class="project-body__leading">
-		<img src={displayImageSrc} alt={displayImageAlt} class="project-body__image" />
+<!-- header Impact snippet -->
+{#snippet headerImpact()}
+	<div class="header-card-root impact">
+		<!-- <Subheader text={impactData.title} color="inverse" /> -->
+		<p class="impact-text">{impactData.content}</p>
 	</div>
 {/snippet}
 
-<!-- trailingContent snippet -->
-{#snippet defaultTrailingContent()}
-	<div class="project-body__trailing">
-		<p class="project-date">date</p>
-		<p class="project-standfirst">Standfirst</p>
-		<div class="project-body__content">
-			<Subheader text="Project Overview" />
-			<p>{displayContent}</p>
-		</div>
+<!-- header Team Members snippet -->
+{#snippet headerTeamMembers()}
+	<div class="header-card-root team">
+		<Subheader text="Team" />
+		<List items={teamMembersData.members} itemFormat="structured" />
 	</div>
 {/snippet}
 
-<section class="project-body">
-	<!-- Leading Content -->
-	{#if leadingContent}
-		{@render leadingContent()}
-	{:else}
-		{@render defaultLeadingContent()}
-	{/if}
-
-	<!-- Trailing Content -->
-	{#if trailingContent}
-		{@render trailingContent()}
-	{:else}
-		{@render defaultTrailingContent()}
-	{/if}
+<section class="project-header">
+	{@render headerImpact()}
+	{@render headerTeamMembers()}
 </section>
 
 <style>
-	.project-body {
+	/* Mobile First - Default styles */
+	.project-header {
 		display: grid;
 		grid-template-columns: 1fr;
+		gap: var(--space-xl);
 	}
 
-	/* Tablet: 767px - 1024px */
-	@media (min-width: 767px) {
-		.project-body {
-			grid-template-columns: 1fr 1fr;
-		}
-
-		.project-body__leading {
-			grid-column: 1;
-		}
-
-		.project-body__trailing {
-			grid-column: 2;
-		}
+	.header-card-root {
+		background: rgb(var(--bg-surface));
+		border: 1px solid rgb(var(--border-primary));
+		border-radius: var(--radius-md);
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		transition: box-shadow 0.2s ease;
+		color: var(--fg-text-primary);
+		padding: var(--space-0) var(--space-xl);
+		border-left: 1px solid var(--fg-text-primary);
 	}
 
-	/* Desktop: 1025px+ */
-	@media (min-width: 1025px) {
-		.project-body {
+	.header-card-root.impact {
+		color: var(--fg-text-primary);
+	}
+
+	.impact-text {
+		font-size: var(--fs-small-clamped);
+		font-weight: var(--fw-bold);
+		line-height: var(--lh-snug);
+		max-width: var(--width-prose-sm);
+	}
+
+	/* Desktop: 1024px+ */
+	@media (min-width: 1024px) {
+		.project-header {
 			grid-template-columns: 1fr 1fr 2fr;
 		}
 
-		.project-body__leading {
+		.header-card-root.impact {
 			grid-column: 1 / 3;
 		}
 
-		.project-body__trailing {
+		.header-card-root.team {
 			grid-column: 3;
 		}
 	}
 
-	.project-body__leading {
-		display: flex;
-		justify-content: center;
-	}
-
-	.project-body__image {
-		width: 100%;
-		height: auto;
-		border-radius: var(--radius-md);
-		box-shadow: var(--shadow-sm);
-		object-fit: cover;
-	}
-
-	.project-body__trailing {
-		display: flex;
-		flex-direction: column;
-		gap: var(--space-lg);
-		padding: var(--space-xl);
-	}
-
-	.project-body__content {
-		max-width: 70ch;
-	}
-
-	.project-body__content p {
-		margin: 0 0 var(--space-md) 0;
-		font-size: var(--fs-300);
-		color: var(--fg-text-primary);
-		font-weight: var(--fw-regular);
-		line-height: var(--lh-body-text);
-	}
-
-	.project-body__content p:last-child {
-		margin-bottom: 0;
-	}
-
-	.project-date {
-		font-size: var(--fs-250);
-		color: var(--fg-text-secondary);
-		margin: 0;
-		font-weight: var(--fw-medium);
-		line-height: var(--lh-interface);
-	}
-
-	.project-standfirst {
-		font-size: var(--fs-500);
-		color: var(--fg-text-primary);
-		margin: 0;
-		font-weight: var(--fw-semibold);
-		font-family: var(--font-family-main);
-		line-height: var(--lh-heading-secondary);
-	}
-
 	/* Debug styles - remove when done */
-	/* .project-body {
+	/* .project-header {
 		box-shadow: 0 0 0 4px solid red !important;
 		outline: 2px solid red !important;
 	}
 
-	.project-body__leading {
+	.header-card-root {
 		box-shadow: 0 0 0 4px solid blue !important;
 		outline: 2px solid blue !important;
 	}
 
-	.project-body__image {
-		box-shadow: 0 0 0 4px solid cyan !important;
-		outline: 2px solid cyan !important;
+	.header-card-root.impact {
+		box-shadow: 0 0 0 4px solid green !important;
+		outline: 2px solid green !important;
 	}
 
-	.project-body__trailing {
-		box-shadow: 0 0 0 4px solid orange !important;
-		outline: 2px solid orange !important;
-	}
 
-	.project-body__content {
+	.header-card-root.team {
 		box-shadow: 0 0 0 4px solid purple !important;
 		outline: 2px solid purple !important;
 	} */

--- a/frontend/src/lib/components/content/projects/ProjectHeader.svelte
+++ b/frontend/src/lib/components/content/projects/ProjectHeader.svelte
@@ -1,220 +1,124 @@
 <script lang="ts">
+	import type { Snippet } from 'svelte';
+	import placeholderImage from '$lib/assets/placeholder-image.jpg';
 	import Subheader from '../../primatives/Subheader.svelte';
-	import TagList from '../../primatives/TagList.svelte';
-	import List from '../../primatives/List.svelte';
 
-	// Interface for props
-	interface ProjectHeaderProps {
-		children?: any;
-		impact?: {
-			title: string;
-			content: string;
-		};
-		categories?: {
-			title: string;
-			tags: string[];
-		};
-		teamMembers?: {
-			title: string;
-			members: { name: string; role: string }[];
-		};
+	// Interface for props following ComponentRules.md patterns
+	interface ProjectBodyProps {
+		leadingContent?: Snippet;
+		trailingContent?: Snippet;
+		content?: string;
+		imageSrc?: string;
+		imageAlt?: string;
 	}
 
-	let { children, impact, categories, teamMembers }: ProjectHeaderProps = $props();
+	let { leadingContent, trailingContent, content, imageSrc, imageAlt }: ProjectBodyProps = $props();
 
 	// Dummy placeholder data for debugging
-	const defaultImpact = {
-		title: 'Impact',
-		content: '10X revenue growth to $300+ MRR'
-	};
+	const defaultContent =
+		'A short description of my role in the project, helping to set the context for the project body content. What did I do, report to and hpw was it received?';
+	const defaultStandfirst = 'A green field design system and multi-platform design system';
 
-	const defaultCategories = {
-		title: 'Categories',
-		tags: ['UX Design', 'Product Strategy', 'User Research', 'Prototyping', 'Design System']
-	};
-
-	const defaultTeamMembers = {
-		title: 'Team Members',
-		members: [
-			{ name: 'Sarah Chen', role: 'Lead Designer' },
-			{ name: 'Marcus Rodriguez', role: 'Frontend Developer' }
-		]
-	};
-
-	// Use provided props or fallback to defaults for debugging
-	const impactData = impact || defaultImpact;
-	const categoriesData = categories || defaultCategories;
-	const teamMembersData = teamMembers || defaultTeamMembers;
+	// Use provided props or fallback to defaults
+	const displayContent = content || defaultContent;
+	const displayImageSrc = imageSrc || placeholderImage;
+	const displayImageAlt = imageAlt || 'Project placeholder image';
 </script>
 
-<!-- header Impact snippet -->
-{#snippet headerImpact()}
-	<div class="header-card-root impact">
-		<Subheader text={impactData.title} color="inverse" />
-		<p class="impact-text">{impactData.content}</p>
+<!-- leadingContent snippet -->
+{#snippet defaultLeadingContent()}
+	<div class="project-body__leading">
+		<img src={displayImageSrc} alt={displayImageAlt} class="project-body__image" />
 	</div>
 {/snippet}
 
-<!-- header Categories snippet -->
-{#snippet headerCategories()}
-	<div class="header-card-root categories">
-		<Subheader text={categoriesData.title} />
-		<div class="categories-content">
-			<TagList tags={categoriesData.tags} />
+<!-- trailingContent snippet -->
+{#snippet defaultTrailingContent()}
+	<div class="project-body__trailing">
+		<p class="project-standfirst">{defaultStandfirst}</p>
+		<div class="project-body__content">
+			<Subheader text="Project Overview" />
+			<p>{displayContent}</p>
 		</div>
 	</div>
 {/snippet}
 
-<!-- header Team Members snippet -->
-{#snippet headerTeamMembers()}
-	<div class="header-card-root team">
-		<Subheader text={teamMembersData.title} />
-		<List items={teamMembersData.members} dual />
-	</div>
-{/snippet}
+<section class="project-body">
+	<!-- Leading Content -->
+	{#if leadingContent}
+		{@render leadingContent()}
+	{:else}
+		{@render defaultLeadingContent()}
+	{/if}
 
-<section class="project-header">
-	<!-- Header Impact -->
-	<div class="header-card-root impact">
-		<Subheader text={impactData.title} color="inverse" />
-		<p class="impact-text">{impactData.content}</p>
-	</div>
-
-	<!-- Header Categories -->
-	<div class="header-card-root categories">
-		<Subheader text={categoriesData.title} />
-		<div class="categories-content">
-			<TagList tags={categoriesData.tags} />
-		</div>
-	</div>
-
-	<!-- Header Team Members -->
-	<div class="header-card-root team">
-		<Subheader text={teamMembersData.title} />
-		<List items={teamMembersData.members} dual />
-	</div>
+	<!-- Trailing Content -->
+	{#if trailingContent}
+		{@render trailingContent()}
+	{:else}
+		{@render defaultTrailingContent()}
+	{/if}
 </section>
 
 <style>
-	.project-header {
+	.project-body {
 		display: grid;
 		grid-template-columns: 1fr;
-		grid-template-rows: auto auto auto;
 	}
 
-	/* Tablet: 767px - 1024px */
-	@media (min-width: 767px) {
-		.project-header {
-			grid-template-columns: 1fr 1fr;
-			grid-template-rows: auto auto;
-		}
-
-		.header-card-root.impact {
-			grid-column: 1;
-			grid-row: 1;
-		}
-
-		.header-card-root.categories {
-			grid-column: 2;
-			grid-row: 1;
-		}
-
-		.header-card-root.team {
-			grid-column: 1 / -1;
-			grid-row: 2;
-		}
+	.project-body__leading {
+		display: flex;
+		justify-content: center;
+		aspect-ratio: 16 / 9;
 	}
 
-	/* Desktop: 1025px+ */
-	@media (min-width: 1025px) {
-		.project-header {
-			grid-template-columns: 1fr 1fr 2fr;
-			grid-template-rows: auto;
-		}
-
-		.header-card-root.impact {
-			grid-column: auto;
-			grid-row: auto;
-		}
-
-		.header-card-root.categories {
-			grid-column: auto;
-			grid-row: auto;
-		}
-
-		.header-card-root.team {
-			grid-column: auto;
-			grid-row: auto;
-		}
-	}
-
-	.header-card-root {
-		background: rgb(var(--bg-surface));
-		border: 1px solid rgb(var(--border-primary));
+	.project-body__image {
+		width: 100%;
 		border-radius: var(--radius-md);
-		padding: var(--space-xl);
+		box-shadow: var(--shadow-sm);
+		object-fit: cover;
+	}
+
+	.project-body__trailing {
 		display: flex;
 		flex-direction: column;
-		gap: var(--space-md);
-		transition: box-shadow 0.2s ease;
-		color: var(--fg-text-primary);
+		justify-content: center;
+		gap: var(--space-lg);
+		padding: var(--space-xl) var(--space-0);
 	}
 
-	.header-card-root.impact {
-		background-color: var(--bg-primary);
-		color: var(--fg-text-inverse);
+	.project-body__content {
+		max-width: 70ch;
 	}
 
-	.impact-text {
-		font-size: var(--fs-large-clamped);
-		font-weight: var(--fw-bold);
-		line-height: var(--lh-snug);
-		max-width: var(--width-prose-sm);
-	}
-
-	.team-member {
-		display: flex;
-		flex-direction: column;
-		gap: var(--space-2xs);
-	}
-
-	.team-member__name {
+	.project-body__content p {
 		font-size: var(--fs-300);
-		font-weight: var(--fw-semibold);
 		color: var(--fg-text-primary);
+		font-weight: var(--fw-regular);
+		line-height: var(--lh-body-text);
+	}
+
+	.project-standfirst {
+		font-size: var(--fs-600);
+		color: var(--fg-text-primary);
+		font-weight: var(--fw-regular);
 		font-family: var(--font-family-main);
+		line-height: var(--lh-snug);
 	}
 
-	.team-member__role {
-		font-size: var(--fs-275);
-		color: var(--fg-text-secondary);
-		font-family: var(--font-family-main);
-		line-height: var(--lh-interface);
-	}
+	/* Desktop: 1024px+ */
+	@media (min-width: 1024px) {
+		.project-body {
+			grid-template-columns: 1fr 1fr 2fr;
+			gap: var(--space-0);
+		}
 
-	/* Debug styles - remove when done */
-	/* .project-header {
-		box-shadow: 0 0 0 4px solid red !important;
-		outline: 2px solid red !important;
-	}
+		.project-body__leading {
+			grid-column: 1 / 3;
+		}
 
-	.header-card-root {
-		box-shadow: 0 0 0 4px solid blue !important;
-		outline: 2px solid blue !important;
+		.project-body__trailing {
+			grid-column: 3;
+			padding: var(--space-xl) var(--space-xl);
+		}
 	}
-
-	.header-card-root.impact {
-		box-shadow: 0 0 0 4px solid green !important;
-		outline: 2px solid green !important;
-	}
-
-	.header-card-root.categories {
-		box-shadow: 0 0 0 4px solid orange !important;
-		outline: 2px solid orange !important;
-	}
-
-	.header-card-root.team {
-		box-shadow: 0 0 0 4px solid purple !important;
-		outline: 2px solid purple !important;
-	} */
 </style>

--- a/frontend/src/lib/components/primatives/List.svelte
+++ b/frontend/src/lib/components/primatives/List.svelte
@@ -1,25 +1,35 @@
 <script lang="ts">
 	interface ListProps {
 		items?: string[] | { name: string; role: string }[];
-		dual?: boolean;
+		itemFormat?: 'string' | 'structured';
 		type?: 'plain' | 'bullet' | 'number' | 'custom';
 		customStyle?: string;
 	}
 
-	let { items = [
-		"John Smith – Developer",
-		"Sarah Johnson – Designer", 
-		"Mike Chen – Product Manager",
-		"Emily Davis – QA Engineer",
-		"Alex Rodriguez – DevOps"
-	], dual = false, type = 'plain', customStyle }: ListProps = $props();
+	let {
+		items = [
+			'John Smith – Developer',
+			'Sarah Johnson – Designer',
+			'Mike Chen – Product Manager',
+			'Emily Davis – QA Engineer',
+			'Alex Rodriguez – DevOps'
+		],
+		itemFormat = 'string',
+		type = 'plain',
+		customStyle
+	}: ListProps = $props();
 </script>
 
-<ul class="list list--{type}" style={type === 'custom' && customStyle ? `list-style: ${customStyle}` : undefined}>
+<ul
+	class="list list--{type}"
+	style={type === 'custom' && customStyle ? `list-style: ${customStyle}` : undefined}
+>
 	{#each items as item}
-		<li>
-			{#if dual && typeof item === 'object'}
-				{item.name} – {item.role}
+		<li class="list__item list__item--{itemFormat}">
+			{#if itemFormat === 'structured' && typeof item === 'object'}
+				<span class="list__item-name">{item.name}</span>
+				<span class="list__item-separator">–</span>
+				<span class="list__item-role">{item.role}</span>
 			{:else}
 				{item}
 			{/if}
@@ -29,7 +39,6 @@
 
 <style>
 	.list {
-		margin: 0;
 		padding: 0;
 	}
 
@@ -49,5 +58,26 @@
 
 	.list--custom {
 		padding-left: 1.5em;
+	}
+
+	.list__item--structured {
+		display: flex;
+		align-items: baseline;
+		gap: 0.25em;
+	}
+
+	.list__item-name {
+		font-weight: 500;
+		white-space: nowrap;
+	}
+
+	.list__item-separator {
+		color: var(--fg-text-secondary, #666);
+		white-space: nowrap;
+	}
+
+	.list__item-role {
+		color: var(--fg-text-secondary, #666);
+		white-space: nowrap;
 	}
 </style>

--- a/frontend/src/lib/components/primatives/Subheader.svelte
+++ b/frontend/src/lib/components/primatives/Subheader.svelte
@@ -18,6 +18,7 @@
 		font-weight: var(--fw-semibold);
 		line-height: 1.4;
 		letter-spacing: 0.02em;
+		padding-bottom: var(--space-sm);
 	}
 
 	.subheader.primary {

--- a/frontend/src/lib/components/primatives/Tag.svelte
+++ b/frontend/src/lib/components/primatives/Tag.svelte
@@ -20,7 +20,7 @@
 		font-weight: var(--fw-semibold);
 		background-color: var(--bg-primary);
 		color: var(--fg-text-inverse);
-		border-radius: var(--bdr-radius-pill);
+		border-radius: var(--bdr-radius-tiny);
 		white-space: nowrap;
 	}
 </style>

--- a/frontend/src/lib/components/topNav/ChatTrigger.svelte
+++ b/frontend/src/lib/components/topNav/ChatTrigger.svelte
@@ -36,12 +36,12 @@
 		justify-content: center;
 		width: var(--width-4xl);
 		aspect-ratio: 4 / 5;
-		background-color: rgba(var(--bg-page) / 0);
+		background-color: var(--bg-page);
 		border: none;
 		border-radius: var(--bdr-radius-small);
 		cursor: pointer;
 		padding: 4px;
-		box-shadow: inset 0 0 0 1px rgba(var(--fg-text-primary) / 1);
+		box-shadow: inset 0 0 0 1px var(--fg-text-primary);
 		container-type: inline-size;
 	}
 

--- a/frontend/src/routes/experience/+page.svelte
+++ b/frontend/src/routes/experience/+page.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
 	import Accordian from '$lib/components/accordian/Accordian.svelte';
 	import AccordionList from '$lib/components/accordian/AccordionList.svelte';
-	import { ProjectCard, ProjectHeader, ProjectBody, ProjectFooter } from '$lib/components/content/projects';
+	import {
+		ProjectCard,
+		ProjectHeader,
+		ProjectBody,
+		ProjectFooter
+	} from '$lib/components/content/projects';
 </script>
 
 <AccordionList>


### PR DESCRIPTION
This pull request refactors and reorganizes components in the project, focusing on improving the structure and functionality of the `ProjectHeader` and `ProjectBody` components, updating the `List` component for better flexibility, and making minor styling adjustments across other components. The most important changes are outlined below:

### Refactor of `ProjectHeader` and `ProjectBody` Components
* Replaced `ProjectBody` with a new `ProjectHeader` structure, introducing `impact` and `teamMembers` props for displaying project details like impact metrics and team members. The old `leadingContent` and `trailingContent` props were removed. (`frontend/src/lib/components/content/projects/ProjectBody.svelte`, [frontend/src/lib/components/content/projects/ProjectBody.svelteL2-R123](diffhunk://#diff-0ae1551f23b29a0fa8935b571b65a389978cf4028c181ba7ca744cf15f429705L2-R123))
* Reversed the roles of `ProjectHeader` and `ProjectBody`, with `ProjectBody` now handling content such as images and descriptions, while `ProjectHeader` focuses on structured metadata. (`frontend/src/lib/components/content/projects/ProjectHeader.svelte`, [frontend/src/lib/components/content/projects/ProjectHeader.svelteR2-L219](diffhunk://#diff-6ca486c05c705e1ef28b7c209b7f9e825e7ce508e78720515a415582b7050f0dR2-L219))

### Update to `List` Component
* Added an `itemFormat` prop to the `List` component, allowing for structured display of items (e.g., name and role pairs) in addition to plain strings. (`frontend/src/lib/components/primatives/List.svelte`, [frontend/src/lib/components/primatives/List.svelteL4-R32](diffhunk://#diff-195fea05666f523f0ed3da5d9b40fa523c50ee601d89797199eddcc3f03da5a6L4-R32))
* Introduced new styles for structured list items, including separate styles for names, separators, and roles. (`frontend/src/lib/components/primatives/List.svelte`, [frontend/src/lib/components/primatives/List.svelteR62-R82](diffhunk://#diff-195fea05666f523f0ed3da5d9b40fa523c50ee601d89797199eddcc3f03da5a6R62-R82))

### Styling Adjustments
* Added padding to the bottom of the `Subheader` component for improved spacing. (`frontend/src/lib/components/primatives/Subheader.svelte`, [frontend/src/lib/components/primatives/Subheader.svelteR21](diffhunk://#diff-b04ad2266e8ba4b2bdc875372b8e236a9aaac426dae9705c9950ad451862a246R21))
* Updated border radius in the `Tag` component to use a smaller radius (`--bdr-radius-tiny`). (`frontend/src/lib/components/primatives/Tag.svelte`, [frontend/src/lib/components/primatives/Tag.svelteL23-R23](diffhunk://#diff-c4bf30423d98571297ecdc1aee40d2089c9f950e55a94c5a8e9eda72336024eaL23-R23))
* Adjusted the `ChatTrigger` component's background color and box-shadow for consistency with the design system. (`frontend/src/lib/components/topNav/ChatTrigger.svelte`, [frontend/src/lib/components/topNav/ChatTrigger.svelteL39-R44](diffhunk://#diff-e16f63784f2d14f9a30bc7be609e1a71a2f23e113d9c5102efc2031e752f5cd5L39-R44))

### Minor Adjustments
* Updated import formatting in the `experience` route for better readability. (`frontend/src/routes/experience/+page.svelte`, [frontend/src/routes/experience/+page.svelteL4-R9](diffhunk://#diff-b5d515e53462f591e895a7cdc4883cbbb742675a56cbd8d123e0fe4a287a48c9L4-R9))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project sections now display dedicated "Impact" and "Team Members" areas with improved layout and styling.
* **Refactor**
  * Project header and body components restructured for clearer separation and more focused content presentation.
  * List component updated to support both simple and structured item formats for enhanced flexibility.
* **Style**
  * Refined styles for project layouts, subheaders, tags, and chat trigger button for a more cohesive visual experience.
* **Chores**
  * Reformatted import statements for improved code readability (no user-facing impact).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->