### PR TITLE
hotfix: refactored chat component styles to use new tokens

### DIFF
--- a/frontend/src/lib/components/actions/Button.svelte
+++ b/frontend/src/lib/components/actions/Button.svelte
@@ -102,31 +102,31 @@
 	}
 
 	.inverse {
-		background-color: rgba(var(--bg-primary) / 1);
-		box-shadow: inset 0 0px 0px 1px rgba(var(--bg-primary) / 1);
-		color: rgb(var(--fg-text-inverse));
+		background-color: var(--bg-primary);
+		box-shadow: inset 0 0px 0px 1px var(--bg-primary);
+		color: var(--fg-text-inverse);
 	}
 
 	.inverse:hover {
-		background-color: rgba(var(--bg-primary) / 0.9);
+		background-color: var(--bg-primary);
 	}
 
 	.inverse:active {
-		background-color: rgba(var(--bg-primary) / 0.8);
+		background-color: var(--bg-primary);
 	}
 
 	.primary {
-		background-color: rgba(var(--bg-page) / 1);
-		box-shadow: inset 0 0px 0px 1px rgba(var(--bg-inverse) / 1);
-		color: rgb(var(--fg-text-primary));
+		background-color: var(--bg-page);
+		box-shadow: inset 0 0px 0px 1px var(--bg-inverse);
+		color: var(--fg-text-primary);
 	}
 
 	.primary:hover {
-		background-color: rgba(var(--bg-page) / 0.9);
+		background-color: var(--bg-page);
 	}
 
 	.primary:active {
-		background-color: rgba(var(--bg-page) / 0.8);
+		background-color: var(--bg-page);
 	}
 
 	.full-width {

--- a/frontend/src/lib/components/actions/IconButton.svelte
+++ b/frontend/src/lib/components/actions/IconButton.svelte
@@ -54,8 +54,8 @@
 	}
 
 	.inverse {
-		background-color: rgba(var(--bg-primary) / 1);
-		box-shadow: inset 0 0px 0px 1px rgba(var(--bg-primary) / 1);
+		background-color: var(--bg-primary);
+		box-shadow: inset 0 0px 0px 1px var(--bg-primary);
 	}
 
 	.inverse:hover {
@@ -71,8 +71,8 @@
 	}
 
 	.primary {
-		background-color: rgba(var(--bg-page) / 1);
-		box-shadow: inset 0 0px 0px 1px rgba(var(--bg-inverse) / 1);
+		background-color: var(--bg-page);
+		box-shadow: inset 0 0px 0px 1px var(--bg-inverse);
 	}
 
 	.primary:hover {

--- a/frontend/src/lib/components/chat/ChatDialog.svelte
+++ b/frontend/src/lib/components/chat/ChatDialog.svelte
@@ -99,7 +99,7 @@
 	}
 
 	.chat-dialog::backdrop {
-		background: rgba(0, 0, 0, 0.8);
+		background: var(--bg-page-40);
 		backdrop-filter: blur(4px);
 		animation: fadeIn 0.3s ease-out;
 	}
@@ -112,7 +112,7 @@
 
 	/* Unified dialog content - consistent across all screen sizes */
 	.dialog-content {
-		background: rgb(var(--bg-inverse));
+		background: var(--bg-page);
 		border-radius: 12px 12px 0 0;
 		width: 100vw;
 		max-width: 100%;

--- a/frontend/src/lib/components/chat/ChatInput.svelte
+++ b/frontend/src/lib/components/chat/ChatInput.svelte
@@ -137,8 +137,8 @@
 		display: flex;
 		gap: 0.75rem;
 		align-items: center;
-		background: rgb(var(--bg-primary));
-		border: 1px solid var(--input-border, #e9ecef);
+		background: var(--bg-primary);
+		border: 1px solid #e9ecef;
 		border-radius: var(--bdr-radius-small);
 		padding: 0.75rem 1rem;
 		transition:
@@ -155,7 +155,7 @@
 		/* Prevent zoom on input focus (iOS) - minimum 16px font size */
 		font-size: max(16px, 0.9375rem);
 		line-height: 1.5;
-		color: rgba(var(--fg-text-inverse) / 1);
+		color: var(--fg-text-inverse);
 		min-height: 24px;
 		max-height: 120px;
 		overflow-y: auto;
@@ -163,7 +163,7 @@
 	}
 
 	.message-input::placeholder {
-		color: rgba(var(--fg-text-inverse) / 0.6);
+		color: var(--fg-text-inverse);
 	}
 
 	.message-input:disabled {
@@ -209,7 +209,7 @@
 	.hint-text {
 		font-family: var(--font-family-alt);
 		font-size: var(--fs-250);
-		color: rgba(var(--fg-text-primary) / 0.5);
+		color: var(--fg-text-primary-60);
 	}
 
 	/* Responsive adjustments with iOS-specific fixes */

--- a/frontend/src/lib/components/chat/ChatMessage.svelte
+++ b/frontend/src/lib/components/chat/ChatMessage.svelte
@@ -117,7 +117,7 @@
 					{#each suggestedPrompts as prompt}
 						<Button
 							as="button"
-							variant="inverse"
+							variant="primary"
 							fullWidth={true}
 							label={prompt}
 							handleClick={() => handlePromptClick(prompt)}
@@ -179,7 +179,7 @@
 
 	/* Message bubble styles */
 	.message-bubble {
-		background: rgb(var(--bg-primary));
+		background: var(--bg-primary);
 		border-radius: 18px;
 		padding: 0.75rem 1rem;
 		max-width: 100%;
@@ -188,15 +188,15 @@
 	}
 
 	.user-bubble {
-		background: rgb(var(--bg-primary));
-		color: rgb(var(--fg-text-inverse));
+		background: var(--bg-primary);
+		color: var(--fg-text-inverse);
 		border-radius: var(--bdr-radius-small) var(--bdr-radius-small) 0px var(--bdr-radius-small);
 	}
 
 	.assistant-bubble {
-		background: rgb(var(--bg-inverse));
-		color: rgb(var(--fg-text-primary));
-		border-color: rgb(var(--fg-text-primary));
+		background: var(--bg-inverse);
+		color: var(--fg-text-primary);
+		border-color: var(--fg-text-primary);
 		border-style: solid;
 		border-width: 1px;
 		border-radius: var(--bdr-radius-small) var(--bdr-radius-small) 0px var(--bdr-radius-small);
@@ -216,12 +216,12 @@
 
 	.message-time {
 		font-size: 0.75rem;
-		color: rgba(var(--fg-text-primary) / 1);
+		color: var(--fg-text-primary);
 		opacity: 0.7;
 	}
 
 	.user-meta .message-time {
-		color: rgba(var(--fg-text-primary) / 1);
+		color: var(--fg-text-primary);
 	}
 
 	/* Loading message styles */
@@ -230,8 +230,8 @@
 	}
 
 	.loading-bubble {
-		background: rgb(var(--bg-page) / 0);
-		color: rgb(var(--fg-text-primary));
+		background: var(--bg-page);
+		color: var(--fg-text-primary);
 		border-radius: 18px;
 		padding: 0.75rem 1rem;
 		width: 100%;
@@ -283,7 +283,7 @@
 	/* Welcome message styles */
 	.welcome-message {
 		padding: 2rem 1.5rem;
-		color: rgb(var(--fg-text-primary));
+		color: var(--fg-text-inverse);
 		display: block;
 		text-align: center;
 	}
@@ -299,7 +299,7 @@
 	}
 
 	.suggested-questions {
-		background: rgba(var(--bg-primary) / 0);
+		background: var(--bg-primary);
 		border-radius: 8px;
 		padding: 1rem;
 		max-width: 400px;


### PR DESCRIPTION
This pull request focuses on simplifying and standardizing CSS across multiple components in the frontend codebase by replacing `rgba()` and `rgb()` color functions with CSS variables. Additionally, it includes minor adjustments to component styles for consistency and improved maintainability.

### Standardization of CSS color usage:

* Replaced `rgba()` and `rgb()` color functions with direct references to CSS variables for `background-color`, `color`, and `box-shadow` in `Button.svelte` and `IconButton.svelte`. This improves readability and ensures consistency in color usage. [[1]](diffhunk://#diff-57f87eec9db6551805fc33002a07a013e201a3244add53081fdcd40d6d6a6632L105-R129) [[2]](diffhunk://#diff-e1a5b65edb13c1d1e078819fb6875d599c73acd9ce88c1eebee9a6c166f81e69L57-R58) [[3]](diffhunk://#diff-e1a5b65edb13c1d1e078819fb6875d599c73acd9ce88c1eebee9a6c166f81e69L74-R75)

* Updated `ChatDialog.svelte` to use `var(--bg-page-40)` for the backdrop and `var(--bg-page)` for dialog content background, replacing hardcoded colors. [[1]](diffhunk://#diff-ba4ce669e8397704ac6507d7cfaeb6590a5a96fc3cdbee9ce800cdeedbca143eL102-R102) [[2]](diffhunk://#diff-ba4ce669e8397704ac6507d7cfaeb6590a5a96fc3cdbee9ce800cdeedbca143eL115-R115)

* Modified `ChatInput.svelte` to use CSS variables for `background`, `color`, and placeholder text color, and introduced `var(--fg-text-primary-60)` for hint text color. [[1]](diffhunk://#diff-d1fffd9f74ca0ed9e6727122b02e5a9b05a325d4e8ef3a0c6c74dc95b2741b76L140-R141) [[2]](diffhunk://#diff-d1fffd9f74ca0ed9e6727122b02e5a9b05a325d4e8ef3a0c6c74dc95b2741b76L158-R166) [[3]](diffhunk://#diff-d1fffd9f74ca0ed9e6727122b02e5a9b05a325d4e8ef3a0c6c74dc95b2741b76L212-R212)

* Updated `ChatMessage.svelte` to use CSS variables for message bubble backgrounds, text colors, and other elements like loading bubbles and welcome messages. [[1]](diffhunk://#diff-b2fdcf9d5fa3313280646b0c3e4e98ec18d6650874df906d50d8ad1591bb6c4fL182-R182) [[2]](diffhunk://#diff-b2fdcf9d5fa3313280646b0c3e4e98ec18d6650874df906d50d8ad1591bb6c4fL191-R199) [[3]](diffhunk://#diff-b2fdcf9d5fa3313280646b0c3e4e98ec18d6650874df906d50d8ad1591bb6c4fL219-R224) [[4]](diffhunk://#diff-b2fdcf9d5fa3313280646b0c3e4e98ec18d6650874df906d50d8ad1591bb6c4fL233-R234) [[5]](diffhunk://#diff-b2fdcf9d5fa3313280646b0c3e4e98ec18d6650874df906d50d8ad1591bb6c4fL286-R286) [[6]](diffhunk://#diff-b2fdcf9d5fa3313280646b0c3e4e98ec18d6650874df906d50d8ad1591bb6c4fL302-R302)

### Minor style adjustments:

* Changed the button variant for suggested prompts in `ChatMessage.svelte` from `inverse` to `primary` for better alignment with the updated design.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated button and chat component styles to use direct CSS variable references for colors, improving consistency and simplifying theming.
  * Adjusted background, border, and text colors for buttons, chat dialog, chat input, and chat messages for a more unified appearance.
  * Changed suggested prompt buttons in chat messages from "inverse" to "primary" variant for visual clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->