### PR TITLE
refactor: updated theme manager to use existing theme

### DIFF
--- a/frontend/src/lib/components/accordian/Accordian.svelte
+++ b/frontend/src/lib/components/accordian/Accordian.svelte
@@ -18,6 +18,7 @@
 		suffix: string;
 		enableShuffleAnimation?: boolean;
 		brand?: BrandKey;
+		themeOverride?: 'light' | 'dark' | 'high-contrast';
 	}
 
 	let {
@@ -25,7 +26,8 @@
 		label = 'Replace me',
 		suffix = 'test',
 		enableShuffleAnimation = true,
-		brand
+		brand,
+		themeOverride
 	}: AccordianProps = $props();
 
 	const accordionState = $state(createAccordionState());
@@ -50,13 +52,15 @@
 	let previousIsOpen = false;
 	let isAnimating = false;
 
-	// Apply brand color when accordion state changes
+	// Apply brand-theme override when accordion state changes
 	$effect(() => {
 		const isOpen = accordionState.isOpen;
 		const currentBrand = brand;
+		const currentThemeOverride = themeOverride;
 
 		console.log('🪗 Accordion effect:', {
 			brand: currentBrand,
+			themeOverride: currentThemeOverride,
 			isOpen,
 			previousIsOpen,
 			stateChanged: isOpen !== previousIsOpen
@@ -64,17 +68,37 @@
 
 		// Only act if state actually changed
 		if (isOpen !== previousIsOpen) {
-			if (currentBrand) {
+			// New brand-theme system
+			if (currentBrand && currentThemeOverride) {
 				if (isOpen) {
-					console.log('🪗 Opening - setting brand:', currentBrand);
+					console.log('🪗 Opening - setting brand-theme override:', {
+						brand: currentBrand,
+						theme: currentThemeOverride
+					});
+					themeManager.setBrandThemeOverride(currentBrand, currentThemeOverride);
+				} else {
+					// Only clear if this accordion's combination is currently active
+					const currentOverride = themeManager.brandThemeOverride;
+					if (currentOverride?.brand === currentBrand && currentOverride?.theme === currentThemeOverride) {
+						console.log('🪗 Closing - clearing brand-theme override');
+						themeManager.clearBrandThemeOverride();
+					} else {
+						console.log('🪗 Closing - NOT clearing (different override active)');
+					}
+				}
+			}
+			// Fallback to legacy brand system if only brand specified
+			else if (currentBrand && !currentThemeOverride) {
+				if (isOpen) {
+					console.log('🪗 Opening - setting brand (legacy):', currentBrand);
 					themeManager.setActiveBrand(currentBrand);
 				} else {
 					// Only clear brand if this accordion was the one that set it
 					if (themeManager.activeBrand === currentBrand) {
-						console.log('🪗 Closing - clearing brand (was active)');
+						console.log('🪗 Closing - clearing brand (legacy, was active)');
 						themeManager.clearBrand();
 					} else {
-						console.log('🪗 Closing - NOT clearing brand (not active)');
+						console.log('🪗 Closing - NOT clearing brand (legacy, not active)');
 					}
 				}
 			}

--- a/frontend/src/lib/components/primatives/Tag.svelte
+++ b/frontend/src/lib/components/primatives/Tag.svelte
@@ -25,13 +25,13 @@
 
 	.tag--primary {
 		background-color: transparent;
-		color: var(--fg-text-inverse);
+		color: var(--fg-text-primary);
 		box-shadow: 0 0 0 1px currentColor;
 	}
 
 	.tag--inverse {
 		background-color: transparent;
-		color: var(--bg-surface);
+		color: var(--bg---fg-text-inverse);
 		box-shadow: 0 0 0 1px currentColor;
 	}
 </style>

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -19,11 +19,12 @@
 		console.log('Theme manager initialized with state:', themeManager.current);
 	});
 	
-	// Clear brand colors when navigating away from experience page
+	// Clear theme overrides when navigating between pages
 	beforeNavigate(({ from, to }) => {
-		// If we're navigating away from experience page, clear brand
-		if (from?.url.pathname === '/experience' && to?.url.pathname !== '/experience') {
-			themeManager.clearBrand();
+		// Clear any active theme overrides when navigating
+		if (from && to && from.url.pathname !== to.url.pathname) {
+			console.log('🎨 Navigation detected, clearing theme overrides');
+			themeManager.clearAllOverrides();
 		}
 	});
 

--- a/frontend/src/routes/experience/+page.svelte
+++ b/frontend/src/routes/experience/+page.svelte
@@ -11,14 +11,15 @@
 	} from '$lib/components/content/projects';
 	import { experienceData } from '$lib/data/experienceData';
 
-	// Clear any active brand when leaving the page
+	// Clear any active theme overrides when leaving the page
 	onDestroy(() => {
+		themeManager.clearBrandThemeOverride();
 		themeManager.clearBrand();
 	});
 </script>
 
 <AccordionList>
-	<Accordian label="godesk" suffix="Co-Founding Designer" brand="godesk">
+	<Accordian label="godesk" suffix="Co-Founding Designer" brand="godesk" themeOverride="light">
 		<ProjectCard>
 			{#snippet children()}
 				<ProjectHeader
@@ -35,7 +36,7 @@
 		</ProjectCard>
 	</Accordian>
 
-	<Accordian label="fresha" suffix="Design System Lead" brand="fresha">
+	<Accordian label="fresha" suffix="Design System Lead" brand="fresha" themeOverride="light">
 		<ProjectCard>
 			{#snippet children()}
 				<ProjectHeader


### PR DESCRIPTION
This pull request introduces a new "brand-theme override" system to the theme management logic, allowing individual components (like Accordians) to specify both a brand and a theme (light, dark, or high-contrast) for more granular control. It also improves cleanup of theme overrides during navigation, and updates the Tag component's color logic.

**Brand-Theme Override System:**

* Added `themeOverride` prop to the `Accordian` component, enabling it to request a specific theme in addition to a brand. The component now applies and clears brand-theme overrides using new methods in the theme manager. (`frontend/src/lib/components/accordian/Accordian.svelte`) [[1]](diffhunk://#diff-de9cb0c156c54bbcb6cec512e806bcceea5c456c7affebaec712926f872d6adaR21-R30) [[2]](diffhunk://#diff-de9cb0c156c54bbcb6cec512e806bcceea5c456c7affebaec712926f872d6adaL53-R101)
* Updated the theme manager (`ThemeManager` class) to support a `brandThemeOverride` state, with new methods `setBrandThemeOverride`, `clearBrandThemeOverride`, and logic to apply or clear overrides. The applied theme now prioritizes the override if present. (`frontend/src/lib/stores/themeManager.svelte.ts`) [[1]](diffhunk://#diff-945c681351c0df67f278e57ae1955ead41038ebda1b13ec167ec0589d0b537cbR9-R17) [[2]](diffhunk://#diff-945c681351c0df67f278e57ae1955ead41038ebda1b13ec167ec0589d0b537cbR46-R53) [[3]](diffhunk://#diff-945c681351c0df67f278e57ae1955ead41038ebda1b13ec167ec0589d0b537cbL110-R165) [[4]](diffhunk://#diff-945c681351c0df67f278e57ae1955ead41038ebda1b13ec167ec0589d0b537cbR225-R284)

**Navigation and Cleanup Improvements:**

* Added logic to clear all theme overrides when navigating between pages, both via SvelteKit navigation events and browser unload, to avoid stale overrides. (`frontend/src/lib/stores/themeManager.svelte.ts`, `frontend/src/routes/+layout.svelte`) [[1]](diffhunk://#diff-945c681351c0df67f278e57ae1955ead41038ebda1b13ec167ec0589d0b537cbR26) [[2]](diffhunk://#diff-945c681351c0df67f278e57ae1955ead41038ebda1b13ec167ec0589d0b537cbR79-R97) [[3]](diffhunk://#diff-26468d22e429fcceed9c0828e9024a17d908f3aca30e8c5c80a6547a0e772818L22-R27)
* Ensured that leaving the experience page clears both the brand-theme override and the legacy brand override. (`frontend/src/routes/experience/+page.svelte`)

**Component Usage Updates:**

* Updated usage of the `Accordian` component in the experience page to specify `themeOverride="light"` for each brand, demonstrating the new system. (`frontend/src/routes/experience/+page.svelte`)

**Tag Component Color Fixes:**

* Fixed CSS variable usage in the `Tag` component to use the correct foreground color variables for primary and inverse tags. (`frontend/src/lib/components/primatives/Tag.svelte`)