### PR TITLE
refactor: Directory cleanup

### DIFF
--- a/frontend/src/lib/components/experimental/README.md
+++ b/frontend/src/lib/components/experimental/README.md
@@ -1,0 +1,35 @@
+# Experimental Components
+
+This directory contains components that are actively being developed and tested.
+
+## Status: EXPERIMENTAL
+
+**⚠️ Important:** These components are not stable and may change or be removed without notice.
+
+## Current Components
+
+### Dialog Components
+- `TestOne.svelte` - Dialog test component (used in production dialog system)
+- `TestTwo.svelte` - Dialog test component (used in production dialog system)  
+- `TestThree.svelte` - Dialog test component (used in production dialog system)
+
+## Usage
+
+These components are currently integrated into the main dialog system via `overlays/dialog/Root.svelte`. While they are marked as experimental, they are actively used in the application.
+
+## Component Lifecycle
+
+Components in this directory should follow the experimental → stable promotion path:
+
+1. **Experimental** - Active development, may change
+2. **Alpha** - Feature complete, needs testing
+3. **Beta** - Testing phase, API likely stable
+4. **Stable** - Ready for production use
+
+## Moving to Stable
+
+When components are ready for production:
+1. Move to appropriate stable directory
+2. Update imports throughout codebase
+3. Add to main component exports
+4. Update documentation

--- a/frontend/src/lib/components/experimental/dialog/index.ts
+++ b/frontend/src/lib/components/experimental/dialog/index.ts
@@ -1,0 +1,7 @@
+// Experimental Dialog Components
+// These components are currently in testing and may change or be removed
+// DO NOT use in production without confirming stability
+
+export { default as TestOne } from './TestOne.svelte';
+export { default as TestTwo } from './TestTwo.svelte';
+export { default as TestThree } from './TestThree.svelte';

--- a/frontend/src/lib/components/experimental/index.ts
+++ b/frontend/src/lib/components/experimental/index.ts
@@ -1,0 +1,5 @@
+// Experimental Components
+// These components are in active development and testing
+// Component status: EXPERIMENTAL - Use with caution
+
+export * from './dialog';

--- a/frontend/src/lib/components/footer/index.ts
+++ b/frontend/src/lib/components/footer/index.ts
@@ -1,1 +1,0 @@
-export { Footer, FooterTitle } from '../layout/footer/index';

--- a/frontend/src/lib/components/layout/index.ts
+++ b/frontend/src/lib/components/layout/index.ts
@@ -1,4 +1,5 @@
 export { default as Grid } from './Grid.svelte';
 export { default as GridItem } from './GridItem.svelte';
 export { default as BasicLayout } from './BasicLayout.svelte';
+export { Footer, FooterTitle } from './footer';
 

--- a/frontend/src/lib/components/overlays/dialog/Root.svelte
+++ b/frontend/src/lib/components/overlays/dialog/Root.svelte
@@ -5,9 +5,7 @@
   import { browser } from '$app/environment'; // Import browser
 
   import Fresha from './Fresha.svelte';
-  import TestOne from '../../experimental/dialog/TestOne.svelte';
-  import TestTwo from '../../experimental/dialog/TestTwo.svelte';
-  import TestThree from '../../experimental/dialog/TestThree.svelte';
+  import { TestOne, TestTwo, TestThree } from '../../experimental/dialog';
 
   // Reactive statement to check if this dialog should be active
   const isActive = $derived(dialogManager.currentDialog !== null);

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,7 +1,7 @@
 <script>
   import '../app.css';
 
-  import { Footer } from '$lib/components/footer';
+  import { Footer } from '$lib/components/layout';
   import { TopNav } from '$lib/components/top-nav';
 
   import { onMount } from 'svelte';


### PR DESCRIPTION
This pull request introduces an "experimental" components system for the frontend, organizing actively developed dialog components into a dedicated directory with clear documentation and export structure. It also refactors how the `Footer` component is imported throughout the codebase, consolidating its export location and updating all relevant imports.

**Experimental Components System:**

* Added a new `experimental` directory with documentation outlining the lifecycle and usage of experimental components, specifically dialog components (`TestOne`, `TestTwo`, `TestThree`). (`frontend/src/lib/components/experimental/README.md`)
* Created index files to export experimental dialog components, enabling cleaner imports elsewhere in the codebase. (`frontend/src/lib/components/experimental/dialog/index.ts`, `frontend/src/lib/components/experimental/index.ts`) [[1]](diffhunk://#diff-2a64f5f453235a572b7861c34f69930347bf71ff8278a65ba67905e157d594a3R1-R7) [[2]](diffhunk://#diff-61dbacc19f84c204332c4b29eeb2c44b500a666a4d72d3576c6b22bdd0f849bfR1-R5)
* Updated `Root.svelte` in the overlays dialog system to import dialog components from the new experimental index, improving maintainability. (`frontend/src/lib/components/overlays/dialog/Root.svelte`)

**Footer Component Refactor:**

* Moved the export of `Footer` and `FooterTitle` from `footer/index.ts` to `layout/index.ts`, centralizing layout-related exports. (`frontend/src/lib/components/layout/index.ts`, `frontend/src/lib/components/footer/index.ts`) [[1]](diffhunk://#diff-cc5f091be2eff34e354fd689d3bf12aedf9337fe84cfaa5459c34935168cc766R4) [[2]](diffhunk://#diff-1a8f33846ab617b8a26e592f8e37a29855fb7380ac077312f97fdf7a2272edfaL1)
* Updated the import path for `Footer` in `+layout.svelte` to reflect the new export location. (`frontend/src/routes/+layout.svelte`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an overview for Experimental Components, including a stability warning, current test dialog components, and the lifecycle from Experimental to Stable.

* **Refactor**
  * Centralized experimental dialog components behind a single import for cleaner usage; no functional changes.
  * Relocated Footer and FooterTitle exports under the Layout namespace and updated app imports accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->