### PR TITLE
refacor: remove animated text component from the index page

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,64 +1,4 @@
 <script lang="ts">
-  let helloWorld: string = 'Hello world';
-  console.log(helloWorld);
-
-  // components
-  import { page } from '$app/stores';
-  import { MultiPathAnimatedText } from '$lib/components/graphics';
-
-  // Vibrant color pairs for MultiPathAnimatedText
-  const colorPairs = [
-    { background: '#0066FF', foreground: '#FFFF00' }, // Electric Blue & Bright Yellow
-    { background: '#FF1493', foreground: '#32FF32' }, // Hot Pink & Lime Green
-    { background: '#FF4500', foreground: '#9932CC' }, // Orange & Purple
-    { background: '#00FFFF', foreground: '#FF00FF' }, // Cyan & Magenta
-    { background: '#50C878', foreground: '#FFD700' }, // Emerald & Gold
-  ];
-
-  // Configure multiple paths for the component
-  const pathConfigs = [
-    {
-      texts: [
-        'HALLO •',
-        ' HEJ •',
-        'HOLA •',
-        'HELLO •',
-        'WELCOME •',
-        'こんにちは •',
-      ],
-      speed: 70,
-      pathWildness: 0.9,
-      showPath: true,
-      pathStyle: {
-        strokeWidth: 80,
-        opacity: 1,
-      },
-      textStyle: {
-        font: 'bold 28px sans-serif',
-        size: 24,
-      }
-    },
-    {
-      texts: [
-        'LETS COOK –',
-        ' WHY NOT TRY?',
-        'LETS CREATE //',
-        'LETS MAKE //',
-        'LETS EXPLORE //',
-      ],
-      speed: 100,
-      pathWildness: 0.9,
-      showPath: true,
-      pathStyle: {
-        strokeWidth: 80,
-        opacity: 1,
-      },
-      textStyle: {
-        font: 'bold 28px sans-serif',
-        size: 24,
-      }
-    }
-  ];
 </script>
 
 <svelte:head>
@@ -68,12 +8,6 @@
     content="Interactive designer and frontend developer based in Madrid. Available for UI/UX design, development, and consulting projects in Q3 2025."
   />
 </svelte:head>
-
-<MultiPathAnimatedText 
-  paths={pathConfigs}
-  {colorPairs}
-  verticalStacking="random"
-/>
 
 <style>
 </style>


### PR DESCRIPTION
This pull request removes the animated greeting and call-to-action text from the main page by deleting the configuration and usage of the `MultiPathAnimatedText` component. The page will no longer display the animated multilingual welcome messages and creative prompts.

Removed animated text feature:

* Deleted the `MultiPathAnimatedText` component and its configuration, including color pairs and path settings, from `+page.svelte`, resulting in a simpler page without animated greetings or prompts. [[1]](diffhunk://#diff-277e5e66aac69da7616117de4cb91d3988aab163a62ebf7252f86fa6cf4b39eeL2-L61) [[2]](diffhunk://#diff-277e5e66aac69da7616117de4cb91d3988aab163a62ebf7252f86fa6cf4b39eeL72-L77)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the animated text effect from the landing page, resulting in a cleaner, distraction-free experience. This change may reduce CPU/GPU usage on some devices and improve page responsiveness. All other page content, head metadata, and existing styles remain unchanged, so navigation and functionality are unaffected. No new features are introduced in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->