### PR TITLE
refactor: changes styles, IXD and props for a more opinionated component

### DIFF
--- a/docs/components/popover/popover_spec.md
+++ b/docs/components/popover/popover_spec.md
@@ -51,7 +51,8 @@ lib/components/popover/
 interface PopoverProps {
   // Core props
   id: string;                    // Unique popover identifier
-  content: Snippet;              // Popover content as snippet
+  title: string;                 // Popover title text
+  text: string;                  // Popover body text
   
   // Behavior props
   position?: 'top' | 'bottom' | 'left' | 'right'; // Desktop positioning (default: 'bottom')
@@ -70,11 +71,9 @@ interface PopoverProps {
 
 ### Export Compatibility
 
-Both `Popover` and `Popover` exports point to the same unified component:
+The Popover component is exported as a single unified component:
 
 ```typescript
-// All these imports work identically
-import { Popover } from '$lib/components/popover';
 import { Popover } from '$lib/components/popover';
 ```
 
@@ -369,18 +368,12 @@ The Popover component includes an internal trigger snippet that renders a standa
   import { Popover } from '$lib/components/popover';
 </script>
 
-<Popover id="user-menu" position="bottom">
-  {#snippet content()}
-    <div class="menu-content">
-      <h3>User Menu</h3>
-      <ul>
-        <li><button>Profile</button></li>
-        <li><button>Settings</button></li>
-        <li><button>Logout</button></li>
-      </ul>
-    </div>
-  {/snippet}
-</Popover>
+<Popover 
+  id="user-menu" 
+  title="User Menu"
+  text="Select an option from the menu below"
+  position="bottom" 
+/>
 ```
 
 ### Advanced Usage with Callbacks
@@ -400,22 +393,12 @@ The Popover component includes an internal trigger snippet that renders a standa
 
 <Popover 
   id="notifications" 
+  title="Notifications"
+  text="You have 3 new notifications"
   position="top"
   onOpen={handleOpen}
   onClose={handleClose}
->
-  {#snippet content()}
-    <div class="notifications">
-      <header>
-        <h3>Notifications</h3>
-        <button class="close-btn">×</button>
-      </header>
-      <div class="notification-list">
-        <!-- Notification items -->
-      </div>
-    </div>
-  {/snippet}
-</Popover>
+/>
 ```
 
 ### Multiple Popovers
@@ -426,18 +409,20 @@ The Popover component includes an internal trigger snippet that renders a standa
 </script>
 
 <!-- User menu popover -->
-<Popover id="user-menu" position="bottom">
-  {#snippet content()}
-    <div>User settings...</div>
-  {/snippet}
-</Popover>
+<Popover 
+  id="user-menu" 
+  title="User Settings"
+  text="Manage your account preferences"
+  position="bottom" 
+/>
 
 <!-- Notification popover -->  
-<Popover id="notifications" position="bottom">
-  {#snippet content()}
-    <div>Recent notifications...</div>
-  {/snippet}
-</Popover>
+<Popover 
+  id="notifications" 
+  title="Recent Notifications"
+  text="View your latest updates"
+  position="bottom" 
+/>
 ```
 
 ## Accessibility Requirements
@@ -1164,29 +1149,31 @@ The original multi-component approach has been replaced with a unified component
 
 ---
 
-## Architecture Evolution - Internal Trigger Design
+## Architecture Evolution - String Content Props
 
-**Date**: August 26, 2025  
+**Date**: August 27, 2025  
 **Time**: Latest Update  
-**Change Type**: Internal trigger snippet with scoped styles  
+**Change Type**: Replaced content snippet with title and text string props  
 
-### Latest Changes - Internal Trigger Snippet
+### Latest Changes - Simplified String Props
 
-The Popover component has been further refined to include an internal trigger snippet that renders a standardized icon button, eliminating the need for external trigger content while maintaining all functionality.
+The Popover component has been simplified to use string props for content instead of snippets, making it easier to use while maintaining all functionality.
 
 #### Key Changes:
-1. **Removed `trigger` prop** - No longer accepts external trigger content
-2. **Internal trigger snippet** - Renders standardized icon button with scoped styles  
-3. **Simplified API** - Parent components only provide `content` snippet
-4. **Consistent UX** - All popovers have identical trigger appearance
-5. **Centralized styling** - Trigger styles are scoped within the component
+1. **Removed `content` snippet prop** - No longer accepts snippet content
+2. **Added `title` string prop** - Displays popover title in semantic h3 element  
+3. **Added `text` string prop** - Displays popover body text in semantic p element
+4. **Simplified API** - Parent components only provide strings for content
+5. **Semantic HTML** - Content automatically wrapped in proper semantic elements
+6. **Consistent styling** - Title and text have dedicated CSS classes with design tokens
 
 #### New Simplified Interface:
 ```typescript
 interface PopoverProps {
   // Core props
   id: string;                    // Unique popover identifier
-  content: Snippet;              // Popover content as snippet (only required snippet)
+  title: string;                 // Popover title text
+  text: string;                  // Popover body text
   
   // All other props remain the same
   position?: 'top' | 'bottom' | 'left' | 'right';
@@ -1623,7 +1610,35 @@ The popover component has been significantly enhanced with hardened interaction 
 
 ### Key Improvements in v2.3.0
 
-#### 1. **Hover Interaction Hardening**
+#### 1. **Keyboard vs Mouse Focus Distinction**
+- **Pointer Tracking**: Uses `pointerdown` event to detect mouse/touch interactions
+- **Keyboard-Only Focus**: Only opens popover when focus comes from keyboard (Tab key)
+- **Mouse Click Prevention**: Clicking on desktop no longer triggers popover opening
+- **Accessibility First**: Ensures keyboard users can access popover content easily
+
+```typescript
+// Track if focus is from mouse/touch
+let isPointerDown = false;
+
+function handleTriggerPointerDown() {
+  // Mark that pointer is being used (not keyboard)
+  isPointerDown = true;
+}
+
+function handleTriggerFocus() {
+  // Only open on keyboard focus, not mouse focus
+  if (isPointerDown) {
+    isPointerDown = false;
+    return;
+  }
+  
+  isFocusWithin = true;
+  clearTimers();
+  openPopover();
+}
+```
+
+#### 2. **Hover Interaction Hardening**
 - **Linger Requirement**: Mouse must remain in trigger area for initial check period before hover delay begins
 - **Mouse Position Tracking**: Verifies mouse is still within trigger bounds before opening
 - **Increased Delays**: 
@@ -1811,9 +1826,9 @@ The hardened interaction design in v2.3.0 establishes a solid foundation for:
 
 ---
 
-**Version**: 2.3.0 - Hardened Interaction Design  
-**Last Updated**: August 25, 2025  
-**Status**: Production Ready - Enhanced UX with Robust Focus Management & Scroll-to-Close
+**Version**: 2.4.0 - Simplified String Props & Focus Management  
+**Last Updated**: August 27, 2025  
+**Status**: Production Ready - String Content Props with Keyboard/Mouse Focus Distinction
 
 ### Key Improvements in v2.3.0
 - ✅ Hardened hover interaction with linger requirements (300ms total)
@@ -1825,5 +1840,5 @@ The hardened interaction design in v2.3.0 establishes a solid foundation for:
 - ✅ Optimized event listener management
 - ✅ Consolidated state management with `clearTimers()` utility
 
-**Previous Version**: 2.2.0 - Opinionated Design with Enhanced Positioning  
-**Migration**: Fully backward compatible - no code changes required
+**Previous Version**: 2.3.0 - Hardened Interaction Design  
+**Migration**: Breaking change - content snippet replaced with title/text string props

--- a/frontend/src/lib/components/navigation/TopNav.svelte
+++ b/frontend/src/lib/components/navigation/TopNav.svelte
@@ -18,6 +18,10 @@
   ];
 
   let { list = defaultListData }: TopNavProps = $props();
+
+  let popoverTitle = "Hey there!";
+  let popoverText =
+    "This site is built using Svelte5.js, Vite and is hosted on Vercel with a little help from Claude. ❤️";
 </script>
 
 <section class="top-nav-root">
@@ -26,14 +30,12 @@
       <LinkList {list} />
     </header>
   </div>
-  <Popover id="bottom-position" position="bottom">
-    {#snippet content()}
-      <div class="popover-content">
-        <p>👉 From the right!</p>
-        <button>Action Button</button>
-      </div>
-    {/snippet}
-  </Popover>
+  <Popover
+    id="bottom-position"
+    position="bottom"
+    title={popoverTitle}
+    text={popoverText}
+  />
 </section>
 
 <style>

--- a/frontend/src/lib/components/popover/Popover.svelte
+++ b/frontend/src/lib/components/popover/Popover.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { onMount, onDestroy } from "svelte";
-  import type { Snippet } from "svelte";
   import {
     positionWrapper,
     calculatePosition,
@@ -12,7 +11,8 @@
   interface PopoverProps {
     // Core props
     id: string;
-    content: Snippet;
+    title: string;
+    text: string;
 
     // Behavior props
     position?: Position;
@@ -32,7 +32,8 @@
 
   let {
     id,
-    content,
+    title,
+    text,
     position = "bottom",
     disabled = false,
     mobileSheet = true,
@@ -52,7 +53,10 @@
   let contentElement = $state<HTMLElement>();
   let popoverWrapper = $state<HTMLElement>();
   let isOpen = $state(false);
-  let isMobile = $state(false);
+  // Initialize isMobile based on window width if available
+  let isMobile = $state(
+    typeof window !== "undefined" ? window.innerWidth <= 767 : false,
+  );
   let actualPosition = $state(position);
 
   // Interaction state
@@ -62,6 +66,7 @@
   let isMouseOverContent = false;
   let isFocusWithin = false;
   let lastScrollY = 0;
+  let isPointerDown = false; // Track if focus is from mouse/touch
 
   // MediaQuery for mobile detection
   let mediaQuery: MediaQueryList | null = null;
@@ -185,18 +190,26 @@
   }
 
   // Trigger event handlers
+  function handleTriggerPointerDown() {
+    // Mark that pointer is being used (not keyboard)
+    isPointerDown = true;
+  }
+
   function handleTriggerClick(event: MouseEvent) {
     if (disabled) return;
 
-    if (isMobile) {
-      event.stopPropagation();
-      if (isOpen) {
-        closePopover();
-      } else {
-        openPopover();
-      }
+    // Prevent any click behavior on desktop
+    if (!isMobile) {
+      event.preventDefault();
+      return;
     }
-    // On desktop, click doesn't toggle - only hover/focus do
+
+    event.stopPropagation();
+    if (isOpen) {
+      closePopover();
+    } else {
+      openPopover();
+    }
   }
 
   function handleTriggerMouseEnter() {
@@ -213,6 +226,13 @@
 
   function handleTriggerFocus() {
     if (disabled || isMobile) return;
+
+    // Only open on keyboard focus, not mouse focus
+    if (isPointerDown) {
+      isPointerDown = false;
+      return;
+    }
+
     isFocusWithin = true;
     // Focus should open immediately for accessibility
     clearTimers();
@@ -321,6 +341,7 @@
     aria-expanded={isOpen}
     aria-controls="popover-{id}"
     aria-haspopup="dialog"
+    onpointerdown={handleTriggerPointerDown}
     onclick={handleTriggerClick}
     onmouseenter={handleTriggerMouseEnter}
     onmouseleave={handleTriggerMouseLeave}
@@ -356,7 +377,10 @@
     aria-labelledby="popover-{id}-title"
     data-popover-content={id}
   >
-    {@render content()}
+    <div class="popover-content">
+      <h3 class="popover-title">{title}</h3>
+      <p class="popover-text">{text}</p>
+    </div>
   </div>
 {/if}
 
@@ -375,7 +399,10 @@
       onmouseleave={handleContentMouseLeave}
       data-popover-content={id}
     >
-      {@render content()}
+      <div class="popover-content">
+        <h3 class="popover-title">{title}</h3>
+        <p class="popover-text">{text}</p>
+      </div>
     </div>
   </div>
 {/if}
@@ -387,7 +414,7 @@
     width: var(--size-touch-safe);
     height: var(--size-touch-safe);
     border-radius: var(--border-radius-sm);
-    background-color: var(--surface-neutral-reading);
+    background-color: var(--surface-neutral-mask);
     border: none;
     box-shadow: inset 0px 0px 0px 1px var(--border-neutral);
   }
@@ -423,31 +450,33 @@
     left: 0;
     right: 0;
     max-height: 85vh;
-    background: var(--bg-page);
-    border-radius: var(--border-radius-card) var(--border-radius-card) 0 0;
-    padding: var(--spacing-grouped);
+    background: var(--surface-neutral-reading);
+    border-radius: var(--border-radius-sm) var(--border-radius-sm) 0 0;
+    padding-left: var(--spacing-grouped);
+    padding-right: var(--spacing-grouped);
+    padding-top: var(--spacing-grouped);
     padding-bottom: calc(var(--spacing-grouped) + env(safe-area-inset-bottom));
     z-index: 1000;
     overflow-y: auto;
     -webkit-overflow-scrolling: touch;
-    box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.15);
     animation: slideUp 0.3s cubic-bezier(0.32, 0.72, 0, 1);
   }
 
   /* Desktop popover positioned absolutely within wrapper */
   .popover-content-desktop {
     position: absolute;
-    min-width: 200px;
-    max-width: 320px;
-    background: var(--bg-page);
-    border: 1px solid var(--fg-text-muted-60);
-    border-radius: var(--border-radius-card);
+    display: flex;
+    flex-direction: column;
+    width: max-content;
+    background: var(--surface-neutral-mask);
+    border: 1px solid var(--border-neutral);
+    border-radius: var(--border-radius-sm);
     padding: var(--spacing-related-relaxed);
     box-shadow:
       0 8px 24px rgba(0, 0, 0, 0.12),
       0 2px 6px rgba(0, 0, 0, 0.08);
     pointer-events: auto;
-    animation: popIn 0.15s ease;
+    animation: popIn 0.15s ease-in-out;
     will-change: transform, opacity;
   }
 
@@ -496,6 +525,22 @@
       opacity: 1;
       transform: scale(1);
     }
+  }
+
+  /* Content styling */
+  .popover-title {
+    font-size: var(--fs-275);
+    font-weight: var(--fw-medium);
+    color: var(--text-primary-muted);
+    padding-bottom: var(--spacing-related-dense);
+  }
+
+  .popover-text {
+    font-size: var(--fs-275);
+    font-weight: var(--fw-medium);
+    line-height: var(--lh-normal);
+    color: var(--text-primary-default);
+    max-width: var(--width-prose-sm);
   }
 
   /* Reduced motion support */


### PR DESCRIPTION
This pull request introduces a breaking change to the `Popover` component, simplifying its API by replacing the snippet-based `content` prop with string-based `title` and `text` props. It also enhances accessibility and interaction by distinguishing between keyboard and mouse focus, and updates documentation and styling to match the new interface. The changes affect both the implementation and documentation, and require updates to all usages of `Popover`.

**Popover API simplification and breaking change:**

- Replaced the `content` snippet prop with `title` and `text` string props in the `Popover` component, requiring all content to be passed as plain strings. This change is breaking and requires updates to all usages of the component. (`frontend/src/lib/components/popover/Popover.svelte`, `docs/components/popover/popover_spec.md`) [[1]](diffhunk://#diff-e73a0edb108b551df1521093dddb7a16a4dbd7c003af585e2c268a6e38f55701L15-R15) [[2]](diffhunk://#diff-fd724c23926db689b6b1f37c244760f2b847614cbf59b76e1ec583719930d4ccL54-R55) [[3]](diffhunk://#diff-fd724c23926db689b6b1f37c244760f2b847614cbf59b76e1ec583719930d4ccL1167-R1176) [[4]](diffhunk://#diff-fd724c23926db689b6b1f37c244760f2b847614cbf59b76e1ec583719930d4ccL1828-R1844)
- Updated all usages and documentation examples to use the new `title` and `text` props instead of content snippets. (`frontend/src/lib/components/navigation/TopNav.svelte`, `docs/components/popover/popover_spec.md`) [[1]](diffhunk://#diff-113d30b367bf4951b3817f2ba1350d12dc4d07f03fca314bb09ebd5e8164e380L29-R38) [[2]](diffhunk://#diff-fd724c23926db689b6b1f37c244760f2b847614cbf59b76e1ec583719930d4ccL372-R376) [[3]](diffhunk://#diff-fd724c23926db689b6b1f37c244760f2b847614cbf59b76e1ec583719930d4ccR396-R401) [[4]](diffhunk://#diff-fd724c23926db689b6b1f37c244760f2b847614cbf59b76e1ec583719930d4ccL429-R425)

**Accessibility and interaction improvements:**

- Added logic to distinguish between keyboard and mouse/touch focus: popovers now only open on keyboard focus (Tab), not on mouse click, improving accessibility and user intent detection. (`frontend/src/lib/components/popover/Popover.svelte`, `docs/components/popover/popover_spec.md`) [[1]](diffhunk://#diff-e73a0edb108b551df1521093dddb7a16a4dbd7c003af585e2c268a6e38f55701R193-L200) [[2]](diffhunk://#diff-e73a0edb108b551df1521093dddb7a16a4dbd7c003af585e2c268a6e38f55701R229-R235) [[3]](diffhunk://#diff-fd724c23926db689b6b1f37c244760f2b847614cbf59b76e1ec583719930d4ccL1626-R1641)
- Prevented popover opening on desktop click, further refining focus and interaction behavior. (`frontend/src/lib/components/popover/Popover.svelte`)

**Styling and structure updates:**

- Updated popover content rendering to use semantic HTML elements (`<h3>` for title, `<p>` for text) and added dedicated CSS classes for consistent styling and improved accessibility. (`frontend/src/lib/components/popover/Popover.svelte`) [[1]](diffhunk://#diff-e73a0edb108b551df1521093dddb7a16a4dbd7c003af585e2c268a6e38f55701L359-R383) [[2]](diffhunk://#diff-e73a0edb108b551df1521093dddb7a16a4dbd7c003af585e2c268a6e38f55701L378-R405) [[3]](diffhunk://#diff-e73a0edb108b551df1521093dddb7a16a4dbd7c003af585e2c268a6e38f55701R530-R545)
- Refined popover layout and design tokens for both mobile and desktop, including background colors, border radii, and spacing. (`frontend/src/lib/components/popover/Popover.svelte`) [[1]](diffhunk://#diff-e73a0edb108b551df1521093dddb7a16a4dbd7c003af585e2c268a6e38f55701L390-R417) [[2]](diffhunk://#diff-e73a0edb108b551df1521093dddb7a16a4dbd7c003af585e2c268a6e38f55701L426-R479)

**Documentation and migration notes:**

- Updated documentation to reflect the new API, including migration instructions and new usage patterns. Marked the change as a breaking change and updated versioning and changelog notes. (`docs/components/popover/popover_spec.md`) [[1]](diffhunk://#diff-fd724c23926db689b6b1f37c244760f2b847614cbf59b76e1ec583719930d4ccL1167-R1176) [[2]](diffhunk://#diff-fd724c23926db689b6b1f37c244760f2b847614cbf59b76e1ec583719930d4ccL1814-R1831) [[3]](diffhunk://#diff-fd724c23926db689b6b1f37c244760f2b847614cbf59b76e1ec583719930d4ccL1828-R1844)

**Internal code cleanup:**

- Removed unused imports and variables related to the old snippet-based API. (`frontend/src/lib/components/popover/Popover.svelte`) [[1]](diffhunk://#diff-e73a0edb108b551df1521093dddb7a16a4dbd7c003af585e2c268a6e38f55701L3) [[2]](diffhunk://#diff-e73a0edb108b551df1521093dddb7a16a4dbd7c003af585e2c268a6e38f55701L35-R36)

**Migration required:** All usages of the `Popover` component must be updated to use `title` and `text` string props instead of the old snippet-based `content` prop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Popover now uses simple string props (title and text) for content.
  - Improved focus management: opens via keyboard focus; pointer clicks don’t toggle on desktop; mobile taps continue to toggle.
  - Responsive behavior: popover closes on viewport changes to prevent misalignment.

- Refactor
  - Consolidated popover architecture; removed snippet-based content. Breaking change to the public API.

- Style
  - Updated visuals, layout, and animations; semantic title and body text.

- Documentation
  - Updated examples, migration guidance, and version to 2.4.0 (Simplified String Props & Focus Management).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->