### PR TITLE
fix: type issues resolved and docs added

### DIFF
--- a/frontend/src/lib/components/grids/GridLayout.svelte
+++ b/frontend/src/lib/components/grids/GridLayout.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
+  import type { Component } from 'svelte';
   let P: string = "Graphics Page";
   console.log(`${P} rendered!`);
 
   export interface GridItem {
     readonly id: string;
-    readonly component: any;
+    readonly component: Component<Record<string, any>>;
     readonly size: "2-2" | "4-2";
     readonly props?: Record<string, any>;
   }


### PR DESCRIPTION
This pull request makes a small type improvement to the `GridLayout.svelte` component, ensuring better type safety for grid items.

- Improved type safety by updating the `GridItem` interface to specify that the `component` property must be a Svelte `Component` with generic props, instead of using `any`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety for grid layout items to ensure only valid components can be used.
  * No changes to UI or behavior; existing layouts and rendering continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->