### PR TITLE
fix: linklist no longer displays focus state onMouseDown

### DIFF
--- a/docs/components/linkList/LinkList.md
+++ b/docs/components/linkList/LinkList.md
@@ -1,0 +1,61 @@
+# LinkList Component
+
+## Overview
+A navigation component that renders a list of links with active state management and accessibility features.
+
+## Location
+`frontend/src/lib/components/navigation/LinkList.svelte`
+
+## Props
+
+### LinkListProps
+- `list?: LinkItem[]` - Optional array of link items. Defaults to predefined navigation items.
+
+### LinkItem Interface
+```typescript
+interface LinkItem {
+  label: string;
+  href: string;
+}
+```
+
+## Default Data
+- Index (`/`)
+- Graphics (`/graphics`)
+
+## Features
+
+### Active State Management
+- Uses `$page.url.pathname` to determine active links
+- Root path (`/`) requires exact match
+- Other paths use `startsWith()` matching
+- Applies `.active` class to current page links
+
+### Accessibility
+- `aria-label="Main navigation"` on nav element
+- `role="list"` on ul element
+- `aria-label` with descriptive text for each link
+- `aria-current="page"` for active links
+
+### Styling
+- Flexbox horizontal layout with gap
+- Hover and focus-visible states
+- Touch-safe height sizing
+- Custom CSS properties for colors and spacing
+- Smooth transitions (0.2s ease-in-out)
+
+## CSS Classes
+- `.nav-link` - Base link styling
+- `.nav-link:hover` - Hover state
+- `.nav-link.active` - Active page indicator
+- `.nav-link:focus-visible` - Keyboard focus outline
+
+## Usage Example
+```svelte
+<LinkList />
+<!-- or with custom links -->
+<LinkList list={[
+  { label: "Home", href: "/" },
+  { label: "About", href: "/about" }
+]} />
+```

--- a/frontend/src/lib/components/navigation/LinkList.svelte
+++ b/frontend/src/lib/components/navigation/LinkList.svelte
@@ -84,13 +84,13 @@
     color: var(--fg-text-primary);
   }
 
-  .nav-link:focus {
+  .nav-link.active {
+    color: var(--fg-text-primary);
+  }
+
+  .nav-link:focus-visible {
     color: var(--fg-text-primary);
     outline: 2px solid var(--focus-ring-color);
     outline-offset: 2px;
-  }
-
-  .nav-link.active {
-    color: var(--fg-text-primary);
   }
 </style>


### PR DESCRIPTION
This pull request adds comprehensive documentation for the `LinkList` navigation component and improves the accessibility and styling of the component by refining the CSS for active and focus states.

**Documentation:**

* Added a detailed markdown file, `docs/components/linkList/LinkList.md`, that covers the `LinkList` component's purpose, props, default data, features (including active state management and accessibility), CSS classes, and usage examples.

**Styling and Accessibility Improvements:**

* Updated `frontend/src/lib/components/navigation/LinkList.svelte` to:
  * Move the active link styling to a dedicated `.nav-link.active` selector.
  * Refine keyboard accessibility by applying the focus outline only on `.nav-link:focus-visible` instead of all focus events, improving the user experience for keyboard navigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive LinkList component docs covering props, default items, usage examples, accessibility attributes, and styling guidance.

* **Style**
  * Refined navigation link states: active link color handled separately, and focus indicators now appear only on focus-visible for better keyboard accessibility.
  * Improved focus ring visibility and clarity without affecting mouse/touch interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->