### PR TITLE
refactor: removed graphics route

### DIFF
--- a/frontend/src/lib/components/navigation/TopNav.svelte
+++ b/frontend/src/lib/components/navigation/TopNav.svelte
@@ -13,7 +13,6 @@
 
   let defaultListData: LinkItem[] = [
     { label: "Index", href: "/" },
-    { label: "Graphics", href: "/graphics" },
     { label: "Experience", href: "/experience" },
   ];
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- UI/UX
  - Updated the default top navigation to remove the “Graphics” item. The out-of-the-box menu now shows “Index” and “Experience” only.
  - Users will no longer see a “Graphics” tab by default; navigation remains fully configurable.
  - Existing setups that provide a custom navigation list are unaffected; only the default menu has changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->