### PR TITLE
feat(routes): add CV download button to index page

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -3,6 +3,7 @@
   import { QAChat } from "$lib/components/chat";
   import { chatStore } from "$lib/stores/chatStore.svelte.js";
   import AnimatedTextPath from "$lib/components/graphics/AnimatedTextPath.svelte";
+  import Button from "$lib/components/actions/Button.svelte";
 
   function handleChatTriggerClick() {
     chatStore.openChat();
@@ -61,10 +62,19 @@
   </div>
 
   <div class="content">
-    <div class="chat-trigger-container">
-      <ChatTrigger
-        handleClick={handleChatTriggerClick}
-        shouldShowIndicator={chatStore.shouldShowIndicator}
+    <div class="top-bar">
+      <div class="chat-trigger-container">
+        <ChatTrigger
+          handleClick={handleChatTriggerClick}
+          shouldShowIndicator={chatStore.shouldShowIndicator}
+        />
+      </div>
+      <Button
+        as="link"
+        href="/documents/Peter_Abbott_CV_04:08:25.pdf"
+        label="Download CV"
+        variant="primary"
+        target="_blank"
       />
     </div>
 
@@ -110,10 +120,17 @@
     padding: var(--padding-xl);
   }
 
+  .top-bar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: var(--padding-medium) 0;
+    width: 100%;
+  }
+
   .chat-trigger-container {
     display: flex;
     justify-content: flex-start;
-    padding: var(--padding-medium) 0;
   }
 
   .coming-soon {


### PR DESCRIPTION
Add Button component to homepage with download link for CV. Restructure top bar layout to include both ChatTrigger and CV download button in a flex container with space-between alignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Download CV button to the top navigation bar, positioned to the right of the chat trigger. The button opens in a new tab with a primary styling variant. Navigation bar layout was updated for improved spacing and alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->